### PR TITLE
x86/hyperv: Set the VTL2 realmode header on hv_vtl_init_platform

### DIFF
--- a/arch/x86/hyperv/hv_vtl.c
+++ b/arch/x86/hyperv/hv_vtl.c
@@ -64,6 +64,7 @@ void __init hv_vtl_init_platform(void)
 	else {
 		x86_platform.realmode_reserve = x86_init_noop;
 		x86_platform.realmode_init = x86_init_noop;
+		real_mode_header = &hv_vtl_real_mode_header;
 	}
 	x86_init.irqs.pre_vector_init = x86_init_noop;
 	x86_init.timers.timer_init = x86_init_noop;
@@ -372,8 +373,6 @@ int __init hv_vtl_early_init(void)
 	if (!hv_isolation_type_en_snp())
 		apic_update_callback(wakeup_secondary_cpu_64, hv_vtl_wakeup_secondary_cpu);
 
-	if (!hv_isolation_type_tdx())
-		real_mode_header = &hv_vtl_real_mode_header;
 
 
 	return 0;


### PR DESCRIPTION
For the VTL2 hyperv guest, currently the hv_vtl_init_platform() clears x86_platform.realmode_reserve/init while the hv_vtl_early_init() sets the real_mode_header.

Set the real_mode_header together with x86_platform.realmode_reserve/init in hv_vtl_init_platform(). This is ok because x86_platform.realmode_init() is invoked from an early initcall while hv_vtl_init_platform() is called during early boot.

Suggested-by: Thomas Gleixner <tglx@linutronix.de>
Link: https://lore.kernel.org/lkml/87a5ho2q6x.ffs@tglx/