### PR TITLE
[RFC] hv, vtl: Fix the build warning on UACCESS

### DIFF
--- a/include/uapi/linux/mshv.h
+++ b/include/uapi/linux/mshv.h
@@ -355,8 +355,6 @@ struct mshv_vtl_sidecar_info {
 #define MSHV_VTL_RETURN_TO_LOWER_VTL	_IO(MSHV_IOCTL, 0x27)
 #define MSHV_VTL_PVALIDATE	_IOW(MSHV_IOCTL, 0x28, struct mshv_pvalidate)
 #define MSHV_VTL_RMPADJUST	_IOW(MSHV_IOCTL, 0x29, struct mshv_rmpadjust)
-#define MSHV_VTL_HOST_VISIBILITY	_IOW(MSHV_IOCTL, 0x30, struct mshv_host_visibility)
-#define MSHV_VTL_HOST_VISIBILITY_V	_IOW(MSHV_IOCTL, 0x31, struct mshv_host_visibility_v)
 #define MSHV_VTL_TDCALL _IOWR(MSHV_IOCTL, 0x32, struct mshv_tdcall)
 #define MSHV_VTL_READ_VMX_CR4_FIXED1 _IOR(MSHV_IOCTL, 0x33, __u64)
 #define MSHV_VTL_GUEST_VSM_VMSA_PFN	_IOWR(MSHV_IOCTL, 0x34, __u64)


### PR DESCRIPTION
There is a build warning at hv/mshv_vtl_main.c as following:

drivers/hv/mshv_vtl_main.o: warning: objtool: mshv_vtl_ioctl+0x8f7: call to __mshv_vtl_ioctl_host_visibility() with UACCESS enabled

The build warning comes from the
mshv_vtl_smap_save()/mshv_vtl_smap_restore() around __mshv_vtl_ioctl_host_visibility while the
__mshv_vtl_ioctl_host_visibility is not in the uaccess_safe_builtin list in the tools/objtools/check.c.

This save/restore pair is in fact not needed since the only user space access in __mshv_vtl_ioctl_host_visibility() is copy_from_user(), which is protected by stac already.

After careful checking, the
MSHV_VTL_HOST_VISIBILITY/MSHV_VTL_HOST_VISIBILITY_V ioctl are not used by the hvlite, thus we can remove it.