### PR TITLE
mshv_vtl/tdx: Remove hardcoding of VP.ENTER value in RAX

### DIFF
--- a/drivers/hv/mshv_vtl.h
+++ b/drivers/hv/mshv_vtl.h
@@ -159,4 +159,7 @@ static_assert(sizeof(struct mshv_vtl_run) <= 4096);
 #define SEV_GHCB_FORMAT_BASE        0
 #define SEV_GHCB_FORMAT_VTL_RETURN  2
 
+/* TDCALL Instruction Leaf Numbers */
+#define TDG_VP_ENTER 25
+
 #endif /* _MSHV_VTL_H */

--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -852,8 +852,7 @@ noinline void mshv_vtl_return_tdx(void)
 	tdx_vp_state = &vtl_run->tdx_context.vp_state;
 	per_cpu = this_cpu_ptr(&mshv_vtl_per_cpu);
 
-	/* TODO TDX: For now, hardcode VP.ENTER rax value. */
-	u64 input_rax = 25;
+	u64 input_rax = TDG_VP_ENTER;
 	u64 input_rcx = vtl_run->tdx_context.entry_rcx;
 	u64 input_rdx = virt_to_phys((void*) &vtl_run->tdx_context.l2_enter_guest_state);
 


### PR DESCRIPTION
Define a constant and assign it to RAX instead of hardcoding it.

This is same as https://github.com/microsoft/OHCL-Linux-Kernel/pull/32.  I had moved the change to a branch in the forked repo. 