### PR TITLE
OOT! arch, x86: Make side channel messages warnings

### DIFF
--- a/arch/x86/kernel/cpu/bugs.c
+++ b/arch/x86/kernel/cpu/bugs.c
@@ -1106,7 +1106,7 @@ do_cmd_auto:
 
 		if (boot_cpu_data.x86_vendor != X86_VENDOR_AMD &&
 		    boot_cpu_data.x86_vendor != X86_VENDOR_HYGON)
-			pr_err(RETBLEED_UNTRAIN_MSG);
+			pr_warn(RETBLEED_UNTRAIN_MSG);
 
 		mitigate_smt = true;
 		break;
@@ -1164,7 +1164,7 @@ do_cmd_auto:
 			break;
 		default:
 			if (retbleed_mitigation != RETBLEED_MITIGATION_STUFF)
-				pr_err(RETBLEED_INTEL_MSG);
+				pr_warn(RETBLEED_INTEL_MSG);
 		}
 	}
 


### PR DESCRIPTION
The messages themselves mark that as a warning.
Print them at that level

See: https://github.com/microsoft/OHCL-Linux-Kernel/issues/40