### PR TITLE
OOT! x86: pci: Downgrade "PCI: Fatal: No config space access" error

### DIFF
--- a/arch/x86/pci/init.c
+++ b/arch/x86/pci/init.c
@@ -39,7 +39,7 @@ static __init int pci_arch_init(void)
 	pci_direct_init(type);
 
 	if (!raw_pci_ops && !raw_pci_ext_ops)
-		printk(KERN_ERR
+		printk(KERN_INFO
 		"PCI: Fatal: No config space access function found\n");
 
 	dmi_check_pciprobe();


### PR DESCRIPTION
This is bogus in VTL2, a proper fix will follow.

See: https://github.com/microsoft/OHCL-Linux-Kernel/issues/39