### PR TITLE
OOT! x86: pci: Downgrade "PCI devices with unassigned 32-bit BARs" error

### DIFF
--- a/arch/x86/kernel/e820.c
+++ b/arch/x86/kernel/e820.c
@@ -666,8 +666,8 @@ __init void e820__setup_pci_gap(void)
 	if (!found) {
 #ifdef CONFIG_X86_64
 		gapstart = (max_pfn << PAGE_SHIFT) + 1024*1024;
-		pr_err("Cannot find an available gap in the 32-bit address range\n");
-		pr_err("PCI devices with unassigned 32-bit BARs may not work!\n");
+		pr_info("Cannot find an available gap in the 32-bit address range\n");
+		pr_info("PCI devices with unassigned 32-bit BARs may not work!\n");
 #else
 		gapstart = 0x10000000;
 #endif


### PR DESCRIPTION
This is bogus in VTL2, a proper fix will follow.

See: https://github.com/microsoft/OHCL-Linux-Kernel/issues/38