### PR TITLE
OOT! x86/of: Don't log error on the missing IO-APIC unconditionally

### DIFF
--- a/arch/x86/kernel/devicetree.c
+++ b/arch/x86/kernel/devicetree.c
@@ -268,7 +268,7 @@ static void __init dtb_ioapic_setup(void)
 		of_ioapic = 1;
 		return;
 	}
-	pr_err("Error: No information about IO-APIC in OF.\n");
+	pr_debug("Error: No information about IO-APIC in OF.");
 }
 #else
 static void __init dtb_ioapic_setup(void) {}


### PR DESCRIPTION
The x86 OF code reports the missing IO-APIC wihtout any checks whether the IO-APIC presence is required or not. That is due to that part of the code being dovetailed to the Intel MID platform.

Check if the IO-APIC must be available. Log the error only when the IO-APIC is expected to be present.

See: https://github.com/microsoft/OHCL-Linux-Kernel/issues/37