### PR TITLE
OOT! x86: dt: Add a mising new line

### DIFF
--- a/arch/x86/kernel/devicetree.c
+++ b/arch/x86/kernel/devicetree.c
@@ -268,7 +268,7 @@ static void __init dtb_ioapic_setup(void)
 		of_ioapic = 1;
 		return;
 	}
-	pr_debug("Error: No information about IO-APIC in OF.");
+	pr_debug("Error: No information about IO-APIC in OF.\n");
 }
 #else
 static void __init dtb_ioapic_setup(void) {}


### PR DESCRIPTION
Not critical, shows up in the debug output only which is not the default in the production environment.

Signed-off-by: Roman Kisel <romank@linux.microsoft.com>