### PR TITLE
Drivers: hv: mshv_vtl: Speed up PVALIDATE and RPMADJUST to meet perf …

### DIFF
--- a/drivers/hv/Makefile
+++ b/drivers/hv/Makefile
@@ -24,9 +24,10 @@ mshv-y				+= mshv_main.o
 mshv_root-y			:= mshv_root_main.o mshv_synic.o mshv_portid_table.o \
 						mshv_eventfd.o mshv_msi.o mshv_root_hv_call.o hv_call.o
 mshv_vtl-y			:= mshv_vtl_main.o hv_call.o
-mshv_vtl-$(CONFIG_X86_64)	+= mshv_vtl_sidecar.o
+mshv_vtl-$(CONFIG_X86_64)	+= mshv_vtl_sidecar.o mshv_tdx.o
+mshv_vtl-$(CONFIG_SEV_GUEST)	+= mshv_vtl_local_maps.o
 
-mshv_vtl-$(CONFIG_X86_64)	+= mshv_tdx.o
+CFLAGS_mshv_vtl_local_maps.o = -DHV_HYPERV_DEFS
 
 $(obj)/mshv_tdx.o: $(obj)/mshv_tdx_asm_offsets.h
 

--- a/drivers/hv/mshv_vtl_local_maps.c
+++ b/drivers/hv/mshv_vtl_local_maps.c
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) 2024, Microsoft Corporation.
+ *
+ * Author:
+ *   Roman Kisel <romank@linux.microsoft.com>
+ */
+
+/*
+ * Problem
+ * =======
+ * Give each processor a VA range it can briefly use for mapping a PFN range
+ * that might or might not be RAM providing a uniform easy access whether
+ * the PFN range needs to be mapped to a large or a normal page. The existing
+ * kernel API (`kmap_local_page` and `vmap_pfn`) make that easy for the 4KiB
+ * pages only, and for the large pages in the page fault handling or mmap
+ * handling.
+ *
+ * Proposed solution
+ * =================
+ * Choose an unused VA range from the upper half, and dispense VA space
+ * to each processor as a function of its ID. This approach eliminates contention,
+ * allows running processing on several CPUs, and does not require remote TLB
+ * flushes.
+ * [The documentation](https://www.kernel.org/doc/html/v6.6/arch/x86/x86_64/mm.html)
+ * mentions that this VA range ffff800000000000..ffff87ffffffffff of 8TiB size
+ * might be used by the hypervisor. As VTL2 plays the role of the hypervisor
+ * for the lower VTLs, it appears rather justified to choose that VA region.
+ *
+ * Here and below, the 4-level paging is assumed. The generalization to
+ * the 5-level one is straightforward. Maximum number of processors supported is
+ * 2048.
+ *
+ * Let `start` = `ffff800000000000` (PML4 index 256).
+ *
+ * 2MiB maps
+ * =========
+ * To give each processor an ability to map its local 2MiB VA range, one needs
+ * 2048/0x200 = 4 PMD tables. All they way up to PML4, that requires 1 table for
+ * each level. The VA for the local 2MiB maps takes 4GiB for all processors, and
+ * for the processor `N` the 2MiB VA range begins at `start` + `N`*2MiB.
+ *
+ * 4KiB maps
+ * =========
+ * To give each processor an ability to map its local 4KiB VA range, one needs
+ * 2048/0x200 = 4 PTE tables. All the way up to PML4, that requires 1 table for
+ * each paging level. In total, the required VA space is 8MiB of size, and the
+ * 4KiB local VA range for the processor `N` begins at `start` + 4GiB + `N`*4KiB.
+ *
+ * Safety
+ * ======
+ * This kibd of code might be very dangerous to run, and there are many checks
+ * put in place to make sure some random memory won't be mapped and potentially
+ * scribbled over.
+ * 
+ * Usage
+ * =====
+ * The process that wishes to pass PFNs to the kernel for processing with `pvalidate`
+ * and similar (where mapping to some/any VA is needed for the operation), should open
+ * and keep opened `/dev/mshv_local_maps` while these operations are in progress.
+ * Opening is idempotent hence opening several times doesn't change anything for the
+ * process. The processing happens per-CPU with preemption disabled (the watchdogs
+ * receive pets to avoid soft lockup warnings).
+ *
+ * Other approaches
+ * ================
+ * Instead of giving each CPUs its own VMA range that it can brifely map and unmap,
+ * one could consider creating a static linear VM map of all addresses that can be mapped.
+ * That leads to a significant memory consumption by the paging tables. E.g., for
+ * a 512GiB VM, there will be (512<<40)/(1<<21) 2MiB pages and given that the page table
+ * entry occupied 8 bytes that comes down to 2 GiB ((512<<40)/(1<<21)*8/1024/1024/1024)
+ * required by the page tables only. In the context of "pvalidate" and "padjust", one
+ * cannot use the 1GiB pages unfortunately.
+ * In stark contrast to this, the implemented approach requires 14-15 page tables (4KiB each)
+ * for any memory size. The static approach could save on the time required to write a page
+ * table entry (8 bytes) and the local TLB flush. The tests show that there are no
+ * noticable slowdown due to that though.
+ */
+
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/pfn_t.h>
+#include <linux/pgtable.h>
+#include <linux/miscdevice.h>
+#include <linux/sched.h>
+#include <linux/nmi.h>
+#include <linux/clocksource.h>
+#include <asm/page.h>
+#include <asm/pgalloc.h>
+#include <asm/pgtable_types.h>
+
+#include <uapi/hyperv/hvgdk.h>
+
+#include "mshv_vtl_local_maps.h"
+
+MODULE_AUTHOR("Microsoft");
+MODULE_LICENSE("GPL");
+
+struct mshv_local_maps {
+	struct list_head node;
+	void *table;
+	enum mshv_page_type page_type;
+};
+
+static DEFINE_MUTEX(mshv_local_maps_mutex);
+
+#define MAX_HYPERV_CPUS 			(u64)(HV_MAXIMUM_PROCESSORS)
+#define LARGE_PAGE_SIZE 			(u64)(PMD_SIZE)
+#define NORMAL_PAGE_SIZE 			(u64)(PAGE_SIZE)
+#define ENTRIES_PER_PGTABLE			(u64)(0x200)
+
+#if CONFIG_PGTABLE_LEVELS < 5
+#define LOCAL_LARGE_VA_START 		0xffff800000000000ULL
+#else
+#define LOCAL_LARGE_VA_START 		0xff00000000000000ULL
+#endif
+
+#define LOCAL_LARGE_VA_END 			(u64)(LOCAL_LARGE_VA_START + MAX_HYPERV_CPUS*LARGE_PAGE_SIZE)
+#define LOCAL_NORMAL_VA_START 		(u64)(LOCAL_LARGE_VA_END)
+#define LOCAL_NORMAL_VA_END 		(u64)(LOCAL_NORMAL_VA_START + MAX_HYPERV_CPUS*NORMAL_PAGE_SIZE)
+#define LOCAL_VA_START 				(u64)(LOCAL_LARGE_VA_START)
+#define LOCAL_VA_END 				(u64)(LOCAL_NORMAL_VA_END)
+
+static struct mshv_local_maps *mshv_vtl_local_map_list_add_entry(
+	void* table, enum mshv_page_type page_type, struct mshv_local_maps *maps)
+{
+	struct mshv_local_maps *maps_entry;
+
+	maps_entry = kzalloc(sizeof(*maps_entry), GFP_KERNEL);
+	if (maps_entry) {
+		maps_entry->table = table;
+		maps_entry->page_type = page_type;
+		list_add(&maps_entry->node, &maps->node);
+	}
+	return maps_entry;
+}
+
+static void mshv_vtl_teardown_local_maps_no_lock(struct mshv_local_maps *maps);
+
+struct mshv_local_maps *mshv_vtl_setup_local_maps(void)
+{
+	struct mshv_local_maps *maps;
+	u64 page_tables_allocated = 0;
+	u64 vaddr = LOCAL_VA_START;
+
+	maps = kzalloc(sizeof(*maps), GFP_KERNEL);
+	if (!maps)
+		return NULL;
+	INIT_LIST_HEAD(&maps->node);
+
+	mutex_lock(&mshv_local_maps_mutex);
+
+	/* Don't leak that to the log. Uncomment if stuck. */
+	/* pr_debug("%s: PGD %#llx\n", __func__, (u64)(current->active_mm->pgd)); */
+
+	/*
+	 * 8 iterations for 2048 processors, allocating 14 4KiB pages
+	 * (for the 4-level page tables, one more for the 5-level case). That doesn't
+	 * look as a noticable cost of speeding up when using large pages, don't bother
+	 * setting the number of CPUs dynamically.
+	 */
+	while (vaddr < LOCAL_VA_END) {
+		pgd_t *pgdp = pgd_offset(current->active_mm, vaddr);
+		p4d_t *p4dp;
+		pud_t *pudp;
+		pmd_t *pmdp;
+		pte_t *ptep;
+
+		/*
+		 * The indexes in the topmost tables aren't changing for the VA ranges
+		 * we're interested in. Keeping code for them inside the loop for consistency.
+		 */
+		if (pgd_none(*pgdp)) {
+			p4dp = (p4d_t *)get_zeroed_page(GFP_KERNEL);
+			if (!p4dp)
+				goto error;
+			page_tables_allocated++;
+
+			pgd_populate(current->active_mm, pgdp, p4dp);
+			if (!mshv_vtl_local_map_list_add_entry(pgdp, PGD_PAGE, maps))
+				goto error;
+		}
+
+		p4dp = p4d_offset(pgdp, vaddr);
+		if (p4d_none(*p4dp)) {
+			pudp = (pud_t *)get_zeroed_page(GFP_KERNEL);
+			if (!pudp)
+				goto error;
+			page_tables_allocated++;
+
+			p4d_populate(current->active_mm, p4dp, pudp);
+			if (!mshv_vtl_local_map_list_add_entry(p4dp, P4D_PAGE, maps))
+				goto error;
+		}
+
+		pudp = pud_offset(p4dp, vaddr);
+		if (pud_none(*pudp)) {
+			pmdp = (pmd_t *)get_zeroed_page(GFP_KERNEL);
+			if (!pmdp)
+				goto error;
+			page_tables_allocated++;
+
+			pud_populate(current->active_mm, pudp, pmdp);
+			if (!mshv_vtl_local_map_list_add_entry(pudp, PUD_PAGE, maps))
+				goto error;
+		}
+
+		if (vaddr >= LOCAL_NORMAL_VA_START) {
+			pmdp = pmd_offset(pudp, vaddr);
+			if (!pmd_present(*pmdp)) {
+				ptep = (pte_t *)get_zeroed_page(GFP_KERNEL);
+				if (!ptep)
+					goto error;
+				page_tables_allocated++;
+
+				pmd_populate_kernel(current->active_mm, pmdp, ptep);
+				if (!mshv_vtl_local_map_list_add_entry(pmdp, PMD_PAGE, maps))
+					goto error;
+			}
+
+			pte_t *pte = pte_offset_kernel(pmdp, vaddr);
+			if (!pte_present(*pte)) {
+				pte_t *pte = (pte_t *)get_zeroed_page(GFP_KERNEL);
+				if (!pte)
+					goto error;
+				page_tables_allocated++;
+
+				if (!mshv_vtl_local_map_list_add_entry(pte, PTE_PAGE, maps))
+					goto error;
+			}
+		}
+
+		if (vaddr >= LOCAL_NORMAL_VA_START)
+			vaddr += ENTRIES_PER_PGTABLE*NORMAL_PAGE_SIZE;
+		else
+			vaddr += ENTRIES_PER_PGTABLE*LARGE_PAGE_SIZE;
+	}
+
+	pr_debug("%s: page tables allocated %llu\n", __func__, page_tables_allocated);
+	pr_debug("%s: LOCAL_LARGE_VA_START = %#llx\n", __func__, LOCAL_LARGE_VA_START);
+	pr_debug("%s: LOCAL_LARGE_VA_END = %#llx\n", __func__, LOCAL_LARGE_VA_END);
+	pr_debug("%s: LOCAL_NORMAL_VA_START = %#llx\n", __func__, LOCAL_NORMAL_VA_START);
+	pr_debug("%s: LOCAL_NORMAL_VA_END = %#llx\n", __func__, LOCAL_NORMAL_VA_END);
+	pr_debug("%s: LOCAL_VA_START = %#llx\n", __func__, LOCAL_VA_START);
+	pr_debug("%s: LOCAL_VA_END = %#llx\n", __func__, LOCAL_VA_END);
+
+	mutex_unlock(&mshv_local_maps_mutex);
+	return maps;
+
+error:
+	mshv_vtl_teardown_local_maps_no_lock(maps);
+
+	mutex_unlock(&mshv_local_maps_mutex);
+	return NULL;
+}
+
+static void mshv_vtl_teardown_local_maps_no_lock(struct mshv_local_maps *maps)
+{
+	struct mshv_local_maps *maps_entry, *tmp;
+	u64 page_tables_freed = 0;
+
+	/* Clean the top-level entries. */
+
+	u64 vaddr = LOCAL_VA_START;
+	while (vaddr < LOCAL_VA_END) {
+		pgd_t *pgdp = pgd_offset(current->active_mm, vaddr);
+
+		if (!pgd_none(*pgdp))
+			pgd_populate(current->active_mm, pgdp, 0);
+
+		/*
+		 * Likley could iterate over the VA space covered by one top-level entry.
+		 * Or just do this once as the range won't take more than one the top level
+		 * entry.
+		 */
+		if (vaddr >= LOCAL_NORMAL_VA_START)
+			vaddr += ENTRIES_PER_PGTABLE*NORMAL_PAGE_SIZE;
+		else
+			vaddr += ENTRIES_PER_PGTABLE*LARGE_PAGE_SIZE;
+	}
+
+	/* Now remove the memory taken by the page tables. */
+	list_for_each_entry_safe(maps_entry, tmp, &maps->node, node) {
+		free_page((unsigned long)maps_entry->table);
+
+		list_del(&maps_entry->node);
+		kfree(maps_entry);
+
+		page_tables_freed++;
+	}
+
+	pr_debug("teardown complete, %llu pages freed.\n", page_tables_freed);
+}
+
+void mshv_vtl_teardown_local_maps(struct mshv_local_maps *maps)
+{
+	mutex_lock(&mshv_local_maps_mutex);
+	mshv_vtl_teardown_local_maps_no_lock(maps);
+	mutex_unlock(&mshv_local_maps_mutex);
+}
+
+/* Used for debugging only. */
+void __maybe_unused mshv_vtl_dump_local_maps(struct mshv_local_maps *maps)
+{
+	struct mshv_local_maps *maps_entry;
+
+	mutex_lock(&mshv_local_maps_mutex);
+
+	pr_info("dumping mshv_local_maps...\n");
+	list_for_each_entry(maps_entry, &maps->node, node) {
+		switch (maps_entry->page_type) {
+			case PGD_PAGE:
+				pr_info("PGD page allocated at %#llx\n", (u64)(maps_entry->table));
+				break;
+			case P4D_PAGE:
+				pr_info("P4D page allocated at %#llx\n", (u64)(maps_entry->table));
+				break;
+			case PUD_PAGE:
+				pr_info("PUD page allocated at %#llx\n", (u64)(maps_entry->table));
+				break;
+			case PMD_PAGE:
+				pr_info("PMD page allocated at %#llx\n", (u64)(maps_entry->table));
+				break;
+			case PTE_PAGE:
+				pr_info("PTE page allocated at %#llx\n", (u64)(maps_entry->table));
+				break;
+			default:
+				pr_warn("Unknown page type at %#llx\n", (u64)(maps_entry->table));
+				break;
+		}
+	}
+
+	mutex_unlock(&mshv_local_maps_mutex);
+}
+
+static void pet_watchdogs(void)
+{
+	touch_softlockup_watchdog_sync();
+	clocksource_touch_watchdog();
+	rcu_cpu_stall_reset();
+	reset_hung_task_detector();
+	touch_nmi_watchdog();
+}
+
+ssize_t mshv_use_local_page(u64 pfn, bool large, u64 pfn_count, u64 *failed_pfn,
+		mshv_use_local_page_func f, void *param)
+{
+	u32 cpu;
+	u64 vaddr;
+	u64 last_pfn;
+	pgd_t *pgdp;
+	p4d_t *p4dp;
+	pud_t *pudp;
+	pmd_t *pmdp;
+	pte_t* leafp;
+	pteval_t page_flags;
+	ssize_t res = 0;
+
+	*failed_pfn = -1;
+
+	if (large && !IS_ALIGNED(pfn, ENTRIES_PER_PGTABLE))
+		return -EINVAL;
+	if (large && (pfn_count < ENTRIES_PER_PGTABLE))
+		return -EINVAL;
+
+	last_pfn = pfn + pfn_count;
+	if (large && !IS_ALIGNED(last_pfn, ENTRIES_PER_PGTABLE))
+		return -EINVAL;
+
+	cpu = get_cpu();
+	if (large)
+		vaddr = LOCAL_LARGE_VA_START + LARGE_PAGE_SIZE*cpu;
+	else
+		vaddr = LOCAL_NORMAL_VA_START + NORMAL_PAGE_SIZE*cpu;
+
+	pr_debug("%s: requested to process %lld pages starting at %#llx, cpu %d, vaddr %#llx\n",
+			__func__, pfn_count, pfn, cpu, vaddr);
+
+	while (pfn < last_pfn) {
+		/* 
+		 * Map vaddr: read-only, non-execute, and non-global.
+		 *
+		 * The two former flags ensures no data corruption and safety (if
+		 * we take pvalidate as an example, it just reads one byte from
+		 * the mapped page).
+		 *
+		 * The latter one makes flushing TLB cheaper, with just `invlpg`.
+		 *
+		 * `_PAGE_ENC` automatically changes to `0` when no confidential
+		 * pages are supported.
+		 */
+		page_flags = _PAGE_PRESENT | _PAGE_ACCESSED | _PAGE_DIRTY | _PAGE_NX | _PAGE_ENC;
+		pgdp = pgd_offset(current->active_mm, vaddr);
+		if (!pgdp || !pte_present(*(pte_t*)pgdp)) {
+			res = -EFAULT;
+			break;
+		}
+		p4dp = p4d_offset(pgdp, vaddr);
+		if (!p4dp || !pte_present(*(pte_t*)p4dp)) {
+			res = -EFAULT;
+			break;
+		}
+		pudp = pud_offset(p4dp, vaddr);
+		if (!pudp || !pte_present(*(pte_t*)pudp)) {
+			res = -EFAULT;
+			break;
+		}
+		pmdp = pmd_offset(pudp, vaddr);
+		if (!pmdp || (!large && !pte_present(*(pte_t*)pmdp))) {
+			res = -EFAULT;
+			break;
+		}
+
+		if (large) {
+			page_flags |= _PAGE_PSE;
+			leafp = (pte_t *)pmdp;
+		} else {
+			leafp = pte_offset_kernel(pmdp, vaddr);
+			if (!leafp) {
+				res = -EFAULT;
+				break;
+			}
+		}
+
+		/*
+		 * When cleaning the entry, it is purposefully set to `0`,
+		 * hence using a stronger than `pte_present()` condition
+		 * to catch possible errors.
+		 */
+		if (leafp->pte) {
+			pr_warn("%s: the leaf entry is not zero: %#llx, large %d, pfn %#llx, vaddr %#llx\n",
+					__func__, (u64)(leafp->pte), large, pfn, vaddr);
+			res = -EBUSY;
+			break;
+		}
+
+		set_pte(leafp, __pte((pfn << PAGE_SHIFT) | page_flags));
+		asm volatile("": : :"memory"); /* Compiler fence to prevent compiler reordering. */
+
+		/* Use vaddr */
+		res = f((void*)vaddr, param);
+
+		/*
+		 * Unmap vaddr and flush TLB. Other processor couldn't use this VA so omit
+		 * remote TLB flushes. Instead of flipping individual bits (e.g. _PAGE_PRESENT),
+		 * set the entry to `0` as that is an invalid entry on x86_64. That also checks
+		 * with validation.
+		 */
+
+		set_pte(leafp, __pte(0));
+		asm volatile("invlpg (%0)" ::"r" (vaddr) : "memory");
+
+		if (res) {
+			*failed_pfn = pfn;
+			break;
+		}
+
+		/*
+		 * The code runs with preemption disabled, pet the watchdogs every 0x200th
+		 * iteration.
+		 */
+		if (large) {
+			if (IS_ALIGNED(pfn, ENTRIES_PER_PGTABLE*ENTRIES_PER_PGTABLE))
+				pet_watchdogs();
+		} else {
+			if (IS_ALIGNED(pfn, ENTRIES_PER_PGTABLE))
+				pet_watchdogs();
+		}
+
+		if (large)
+			pfn += ENTRIES_PER_PGTABLE;
+		else
+			pfn += 1;
+	}
+
+	put_cpu();
+	pr_debug("%s: result %ld, requested to process %lld pages, not processed %lld pages\n", __func__, res, pfn_count, last_pfn - pfn);
+	return res;
+}

--- a/drivers/hv/mshv_vtl_local_maps.h
+++ b/drivers/hv/mshv_vtl_local_maps.h
@@ -1,0 +1,43 @@
+#ifndef __MSHV_VTL_LOCAL_MAPS_H__
+#define __MSHV_VTL_LOCAL_MAPS_H__
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <linux/kernel.h>
+#include <linux/types.h>
+
+struct mshv_local_maps;
+
+#ifdef CONFIG_SEV_GUEST
+#include <asm/pgtable_64_types.h>
+
+enum mshv_page_type {
+	PGD_PAGE,
+	P4D_PAGE,
+	PUD_PAGE,
+	PMD_PAGE,
+	PTE_PAGE
+};
+
+#define PAGES_PER_PMD 	((u64)(PMD_SIZE / PAGE_SIZE))
+
+struct mshv_local_maps *mshv_vtl_setup_local_maps(void);
+void mshv_vtl_teardown_local_maps(struct mshv_local_maps *maps);
+void mshv_vtl_dump_local_maps(struct mshv_local_maps *maps);
+
+typedef ssize_t (*mshv_use_local_page_func)(void*, void*);
+ssize_t mshv_use_local_page(u64 pfn, bool large, u64 pfn_count, u64 *failed_pfn, mshv_use_local_page_func f, void *param);
+
+#else
+
+inline static struct mshv_local_maps *mshv_vtl_setup_local_maps(void)
+{
+	return NULL;
+}
+
+inline static void mshv_vtl_teardown_local_maps(struct mshv_local_maps *maps)
+{
+}
+
+#endif /* CONFIG_SEV_GUEST */
+
+#endif /* __MSHV_VTL_LOCAL_MAPS_H__ */

--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -46,6 +46,7 @@
 
 #include "mshv.h"
 #include "mshv_vtl.h"
+#include "mshv_vtl_local_maps.h"
 #include "hyperv_vmbus.h"
 
 MODULE_AUTHOR("Microsoft");
@@ -111,6 +112,7 @@ struct mshv_vtl_poll_file {
 
 struct mshv_vtl {
 	struct device *module_dev;
+	struct mshv_local_maps *local_maps;
 	u64 id;
 	refcount_t ref_count;
 };
@@ -1581,7 +1583,35 @@ static void __noreturn mshv_sev_es_terminate(unsigned int set, unsigned int reas
 		asm volatile("hlt\n" : : : "memory");
 }
 
-static long mshv_vtl_ioctl_pvalidate(void __user *pval_user)
+struct mshv_vtl_pvalidate_param {
+	bool use_large_page;
+	u8 validate;
+};
+
+static ssize_t mshv_vtl_use_local_page_pvalidate(void *vaddr, void *param)
+{
+	struct mshv_vtl_pvalidate_param *pval = param;
+	u8 rmp_psize = pval->use_large_page ? RMP_PG_SIZE_2M : RMP_PG_SIZE_4K;
+	u8 validate = pval->validate;
+
+	return pvalidate((u64)vaddr, rmp_psize, validate);
+}
+
+struct mshv_vtl_rmpadjust_param {
+	bool use_large_page;
+	u64 attrs;
+};
+
+static ssize_t mshv_vtl_use_local_page_rmpadjust(void *vaddr, void *param)
+{
+	struct mshv_vtl_rmpadjust_param* rmpadj = param;
+	u8 rmp_psize = rmpadj->use_large_page ? RMP_PG_SIZE_2M : RMP_PG_SIZE_4K;
+	u64 attrs = rmpadj->attrs;
+
+	return rmpadjust((u64)vaddr, rmp_psize, attrs);
+}
+
+static long mshv_vtl_ioctl_pvalidate(void __user* pval_user)
 {
 	u64 pfn_end, pfn;
 	long rc;
@@ -1596,36 +1626,74 @@ static long mshv_vtl_ioctl_pvalidate(void __user *pval_user)
 	if (!pval.page_count)
 		return -ENODATA;
 
+	pr_debug("%s: start_pfn %#llx, page count %#llx, ram %d, validate %d\n",
+			__func__, pval.start_pfn, pval.page_count, pval.ram, pval.validate);
+
 	pfn = pval.start_pfn;
 	pfn_end = pfn + pval.page_count;
-
+	/* The strategy below is to process as few small pages as possible as that is slow */
 	while (pfn < pfn_end) {
-		unsigned long pfns[1] = { pfn };
-		void *vaddr;
+		struct mshv_vtl_pvalidate_param param;
+		bool use_large_page = IS_ALIGNED(pfn, PAGES_PER_PMD) && (pfn_end - pfn >= PAGES_PER_PMD);
+		u64 count = 0;
+		u64 failed_pfn = -1;
+		
+		if (use_large_page) {
+			/* Get the maximum amount of large page in pfn..pfn_end */
+			count = ALIGN_DOWN(pfn_end, PAGES_PER_PMD) - pfn;
+		} else {
+			/*
+			 * If there are some large pages (PAGES_PER_PMD pages) is a large pages,
+			 * process up to the beginning of a large page so that after that
+			 * can process the large pages again. Otherwise, just process the
+			 * small pages.
+			 */
+			if (pfn_end - pfn >= PAGES_PER_PMD)
+				count = ALIGN(pfn, PAGES_PER_PMD) - pfn;
+			else
+				count = pfn_end - pfn;
+		}
+		BUG_ON(!count || count > pval.page_count);
 
-		if (pval.ram)
-			vaddr = kmap_local_page(pfn_to_page(pfn));
-		else
-			vaddr = vmap_pfn(pfns, ARRAY_SIZE(pfns), PAGE_KERNEL);
+		param.use_large_page = use_large_page;
+		param.validate = pval.validate;
 
-		if (!vaddr) {
-			rc = -EINVAL;
-			break;
+		rc = mshv_use_local_page(pfn, use_large_page, count, &failed_pfn, mshv_vtl_use_local_page_pvalidate, &param);
+		if (rc == PVALIDATE_FAIL_SIZEMISMATCH && use_large_page) {
+			/*
+			 * The hypervisor indicated that it smashed the large page into 4KiB ones.
+			 * That may happen if and only if large pages are used. Assert that is true,
+			 * as otherwise something fundamental is broken and the processing has to stop
+			 * as the results are undefined.
+			 */
+			BUG_ON(!IS_ALIGNED(pfn, PAGES_PER_PMD) || (pfn_end - pfn < PAGES_PER_PMD));
+			BUG_ON(!IS_ALIGNED(failed_pfn, PAGES_PER_PMD));
+
+			pfn = failed_pfn;
+			count = PAGES_PER_PMD;
+			use_large_page = false;
+			param.use_large_page = false;
+
+			pr_debug("%s: retrying, large_page %d, pfn %#llx, count %#llx\n", __func__, use_large_page, pfn, count);
+			rc = mshv_use_local_page(pfn, use_large_page, count, &failed_pfn, mshv_vtl_use_local_page_pvalidate, &param);
 		}
 
-		rc = pvalidate((u64)vaddr, RMP_PG_SIZE_4K, pval.validate);
-		if (pval.ram)
-			kunmap_local(vaddr);
-		else
-			vunmap(vaddr);
-		if (WARN(rc, "Failed to pvalidate pfn %#llx, ret %ld", pfn, rc)) {
+		if (WARN(rc, "%s failed for pfn %#llx, ret %ld", __func__, failed_pfn, rc)) {
+			/*
+			 * `sev.h` defines `PVALIDATE_FAIL_NOUPDATE` as `255` in addition to the hardware
+			 * codes. That software error code is returned when the CF is set after the `pvalidate`
+			 * instruction.
+			 * That in and by itself does not mean that there has been an error; the RMP entry might
+			 * just not have been updated as it is already in the requested state. As we don't expect
+			 * overlapping ranges, that is fine.
+			 */
 			if (pval.terminate_on_failure)
 				mshv_sev_es_terminate(SEV_TERM_SET_LINUX, GHCB_TERM_PVALIDATE);
 			else
 				break;
 		}
 
-		++pfn;
+		pfn += count;
 	}
 
 	return rc;
@@ -1648,34 +1716,69 @@ static long mshv_vtl_ioctl_rmpadjust(void __user *rmpa_user)
 
 	pfn = rmpa.start_pfn;
 	pfn_end = pfn + rmpa.page_count;
-
+	/* The strategy below is to process as few small pages as possible as that is slow */
 	while (pfn < pfn_end) {
-		unsigned long pfns[1] = { pfn };
-		void *vaddr;
+		struct mshv_vtl_rmpadjust_param param;
+		bool use_large_page = IS_ALIGNED(pfn, PAGES_PER_PMD) && (pfn_end - pfn >= PAGES_PER_PMD);
+		u64 count = 0;
+		u64 failed_pfn = -1;
+		
+		if (use_large_page) {
+			/* Get the maximum amount of large page in pfn..pfn_end */
+			count = ALIGN_DOWN(pfn_end, PAGES_PER_PMD) - pfn;
+		} else {
+			/*
+			 * If there are some large pages (PAGES_PER_PMD pages) is a large pages,
+			 * process up to the beginning of a large page so that after that
+			 * can process the large pages again. Otherwise, just process the
+			 * small pages.
+			 */
+			if (pfn_end - pfn >= PAGES_PER_PMD)
+				count = ALIGN(pfn, PAGES_PER_PMD) - pfn;
+			else
+				count = pfn_end - pfn;
+		}
+		BUG_ON(!count || count > rmpa.page_count);
 
-		if (rmpa.ram)
-			vaddr = kmap_local_page(pfn_to_page(pfn));
-		else
-			vaddr = vmap_pfn(pfns, ARRAY_SIZE(pfns), PAGE_KERNEL);
+		param.use_large_page = use_large_page;
+		param.attrs = rmpa.value;
 
-		if (!vaddr) {
-			rc = -EINVAL;
-			break;
+		rc = mshv_use_local_page(pfn, use_large_page, count, &failed_pfn, mshv_vtl_use_local_page_rmpadjust, &param);
+		if (rc == PVALIDATE_FAIL_SIZEMISMATCH && use_large_page) {
+			/*
+			 * The hypervisor indicated that it smashed the large page into 4KiB ones.
+			 * That may happen if and only if large pages are used. Assert that is true,
+			 * as otherwise something fundamental is broken and the processing has to stop
+			 * as the results are undefined.
+			 */
+			BUG_ON(!IS_ALIGNED(pfn, PAGES_PER_PMD) || (pfn_end - pfn < PAGES_PER_PMD));
+			BUG_ON(!IS_ALIGNED(failed_pfn, PAGES_PER_PMD));
+
+			pfn = failed_pfn;
+			count = PAGES_PER_PMD;
+			use_large_page = false;
+			param.use_large_page = false;
+
+			pr_debug("%s: retrying, large_page %d, pfn %#llx, count %#llx\n", __func__, use_large_page, pfn, count);
+			rc = mshv_use_local_page(pfn, use_large_page, count, &failed_pfn, mshv_vtl_use_local_page_rmpadjust, &param);
 		}
 
-		rc = rmpadjust((u64)vaddr, RMP_PG_SIZE_4K, rmpa.value);
-		if (rmpa.ram)
-			kunmap_local(vaddr);
-		else
-			vunmap(vaddr);
-		if (WARN(rc, "Failed to rmpadjust pfn %#llx, ret %ld", pfn, rc)) {
+		if (WARN(rc, "%s failed for pfn %#llx, ret %ld", __func__, failed_pfn, rc)) {
+			/*
+			 * `sev.h` defines `PVALIDATE_FAIL_NOUPDATE` as `255` in addition to the hardware
+			 * codes. That software error code is returned when the CF is set after the `pvalidate`
+			 * instruction.
+			 * That in and by itself does not mean that there has been an error; the RMP entry might
+			 * just not have been updated as it is already in the requested state. As we don't expect
+			 * overlapping ranges, that is fine.
+			 */
 			if (rmpa.terminate_on_failure)
 				mshv_sev_es_terminate(SEV_TERM_SET_LINUX, GHCB_TERM_PSC);
 			else
 				break;
 		}
 
-		++pfn;
+		pfn += count;
 	}
 
 	return rc;
@@ -2061,6 +2164,8 @@ static int mshv_vtl_release(struct inode *inode, struct file *filp)
 {
 	struct mshv_vtl *vtl = filp->private_data;
 
+	if (vtl->local_maps)
+		mshv_vtl_teardown_local_maps(vtl->local_maps);
 	kfree(vtl);
 
 	return 0;
@@ -2078,20 +2183,33 @@ static long __mshv_ioctl_create_vtl(void __user *user_arg, struct device *module
 	struct mshv_vtl *vtl;
 	struct file *file;
 	int fd;
+	struct mshv_local_maps *local_maps = NULL;
 
 	vtl = kzalloc(sizeof(*vtl), GFP_KERNEL);
 	if (!vtl)
 		return -ENOMEM;
+	if (hv_isolation_type_snp())
+		local_maps = mshv_vtl_setup_local_maps();
+	if (!local_maps)
+		return -ENOMEM;
 
 	fd = get_unused_fd_flags(O_CLOEXEC);
-	if (fd < 0)
+	if (fd < 0) {
+		if (local_maps)
+			mshv_vtl_teardown_local_maps(local_maps);
 		return fd;
+	}
 	file = anon_inode_getfile("mshv_vtl", &mshv_vtl_fops,
 				  vtl, O_RDWR);
-	if (IS_ERR(file))
+	if (IS_ERR(file)) {
+		if (local_maps)
+			mshv_vtl_teardown_local_maps(local_maps);
 		return PTR_ERR(file);
+	}
+
 	refcount_set(&vtl->ref_count, 1);
 	vtl->module_dev = module_dev;
+	vtl->local_maps = local_maps;
 
 	fd_install(fd, file);
 


### PR DESCRIPTION
…targets

Using 4K pages for pvalidate breaks large VMs in the cloud as that
is very slow. Using 2M pages for mapping arbitrary PFNs (i.e. not
having a tracking struct page*) isn't obvious in the kernel.

Employ the VA gap documented as meant for the hypervisor use for creating local maps.
These are local to the processor and are used to briefly map the PFN requested to
be pvalidate-d or rmpadjust-ed.

The implementation allows to parallelize the load between the CPUs if the user mode
code wishes to do so. The 5-level page tables are supported as well as 4-level ones.

The 64GiB+64VP VMs accept the memory in under a second on average with this change,
and without that that's ~57sec on average.
