### PR TITLE
drivers/hv: disable preemption before sending IPI during sidecar init

### DIFF
--- a/drivers/hv/mshv_vtl_sidecar.c
+++ b/drivers/hv/mshv_vtl_sidecar.c
@@ -76,8 +76,11 @@ void mshv_vtl_sidecar_isr(void)
 
 static void sidecar_signal(struct sidecar_dev *dev, u32 cpu)
 {
-	if (dev->control->request_vector)
+	if (dev->control->request_vector) {
+		preempt_disable();
 		__apic_send_IPI(cpu, dev->control->request_vector);
+		preempt_enable();
+	}
 }
 
 static int sidecar_claim(struct sidecar_dev *dev, u32 cpu, u8 state)


### PR DESCRIPTION
This resolves a kernel panic during sidecar initialization:

<30>[    2.087065] underhill_core::loader:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:load_firmware:  loading UEFI into VTL0
<3>[    2.101267] BUG: using smp_processor_id() in preemptible [00000000] code: tp/45
<4>[    2.107548] caller is debug_smp_processor_id+0x17/0x20
<4>[    2.112004] CPU: 0 PID: 45 Comm: tp Tainted: G S                 6.6.63-microsoft-hcl #1
<4>[    2.118873] Call Trace:
<4>[    2.122194]  <TASK>
<4>[    2.125319]  dump_stack_lvl+0x37/0x50
<4>[    2.128555]  dump_stack+0x10/0x20
<4>[    2.131620]  check_preemption_disabled+0xd0/0xf0
<4>[    2.135618]  debug_smp_processor_id+0x17/0x20
<4>[    2.139226]  __send_ipi_mask+0x31/0x1c0
<4>[    2.142325]  hv_send_ipi_mask+0x15/0x40
<4>[    2.145479]  default_send_IPI_single+0x2c/0x40
<4>[    2.149040]  hv_send_ipi+0x29/0x40
<4>[    2.151957]  sidecar_start+0x49/0x70
<4>[    2.155059]  sidecar_ioctl+0x1da/0x340
<4>[    2.158342]  ? folio_add_lru+0x6b/0xa0
<4>[    2.161650]  ? __fget_light+0xa8/0x130
<4>[    2.164958]  __x64_sys_ioctl+0x3fb/0x980
<4>[    2.168369]  x64_sys_call+0x1bff/0x2010
<4>[    2.171594]  do_syscall_64+0x56/0x80
<4>[    2.174564]  ? irqentry_exit_to_user_mode+0x10/0x30
<4>[    2.178481]  ? irqentry_exit+0x3b/0x50
<4>[    2.181592]  ? exc_page_fault+0x30a/0x600
<4>[    2.185130]  entry_SYSCALL_64_after_hwframe+0x6d/0xd7
<4>[    2.196380] RIP: 0033:0x7f2de3041786