### PR TITLE
hv: mshv: vtl: Use the percpu in/out pages as the hypercall's arguments

### DIFF
--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -2311,7 +2311,8 @@ static int mshv_vtl_hvcall_call(struct mshv_vtl_hvcall_fd *fd,
 				struct mshv_vtl_hvcall __user *hvcall_user)
 {
 	struct mshv_vtl_hvcall hvcall;
-	void *in, *out;
+	void *in, *out, *percpu_in, *percpu_out;
+	unsigned long flags;
 	int ret;
 
 	if (copy_from_user(&hvcall, hvcall_user, sizeof(struct mshv_vtl_hvcall)))
@@ -2335,13 +2336,27 @@ static int mshv_vtl_hvcall_call(struct mshv_vtl_hvcall_fd *fd,
 
 	in = (void *)__get_free_page(GFP_KERNEL);
 	out = (void *)__get_free_page(GFP_KERNEL);
+	if (!in || !out) {
+		ret = -ENOMEM;
+		goto free_pages;
+	}
 
 	if (copy_from_user(in, (void __user *)hvcall.input_ptr, hvcall.input_size)) {
 		ret = -EFAULT;
 		goto free_pages;
 	}
 
-	hvcall.status = hv_do_hypercall(hvcall.control, in, out);
+	local_irq_save(flags);
+
+	percpu_in = *this_cpu_ptr(hyperv_pcpu_input_arg);
+	percpu_out = *this_cpu_ptr(hyperv_pcpu_output_arg);
+	memcpy(percpu_in, in, hvcall.input_size);
+
+	hvcall.status = hv_do_hypercall(hvcall.control, percpu_in, percpu_out);
+
+	memcpy(out, percpu_out, hvcall.output_size);
+
+	local_irq_restore(flags);
 
 	if (copy_to_user((void __user *)hvcall.output_ptr, out, hvcall.output_size)) {
 		ret = -EFAULT;


### PR DESCRIPTION
Commit bf72b7722cc1 breaks the CVM scenario, where the hypercall's in/out arguments must point to decrypted pages. The percpu in/out pages are designed to work for both non-CVM and CVM scenarios (see hv_common_cpu_init()), so let's use these pages as the hypercall's arguments.

Alternatively, we could call the APIs set_memory_decrypted()/encrypted() on the temporary 'in' and 'out' pages here, but that requires more error handling since the APIs might fail, and hence would require more lines of changes.

The __get_free_page() here may fail. Detect that and return -ENOMEM.

Fixes: bf72b7722cc1 ("hv: mshv: vtl: Don't use copy_from/to_user() when interrupts are disabled (#34)")