### PR TITLE
hv: mshv: vtl: Allow aarch64 to use the Hyper-V VTL register page.

### DIFF
--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -245,7 +245,6 @@ static long __mshv_vtl_ioctl_check_extension(u32 arg)
 
 static void mshv_vtl_configure_reg_page(struct mshv_vtl_per_cpu *per_cpu)
 {
-#ifdef CONFIG_X86_64
 	struct hv_register_assoc reg_assoc = {};
 	union mshv_synic_overlay_page_msr overlay = {};
 	struct page *reg_page;
@@ -260,7 +259,7 @@ static void mshv_vtl_configure_reg_page(struct mshv_vtl_per_cpu *per_cpu)
 
 	overlay.enabled = 1;
 	overlay.pfn = page_to_phys(reg_page) >> HV_HYP_PAGE_SHIFT;
-	reg_assoc.name = HV_X64_REGISTER_REG_PAGE;
+	reg_assoc.name = HV_REGISTER_REG_PAGE;
 	reg_assoc.value.reg64 = overlay.as_u64;
 
 	ret = hv_call_set_vp_registers(HV_VP_INDEX_SELF, HV_PARTITION_ID_SELF,
@@ -268,8 +267,11 @@ static void mshv_vtl_configure_reg_page(struct mshv_vtl_per_cpu *per_cpu)
 	if (ret) {
 		__free_page(reg_page);
 
-		if (ret == -EINVAL) {
+		if (ret == -EINVAL || ret == -EACCES) {
 			/*
+			 * EINVAL is returned when the hypervisor predates register page support.
+			 * EACCES is returned when the register page is not available for use.
+			 *
 			 * TODO: replace `ret == -EINVAL` with
 			 *       `ret == HV_STATUS_INVALID_PARAMETER'.
 			 *
@@ -292,6 +294,7 @@ static void mshv_vtl_configure_reg_page(struct mshv_vtl_per_cpu *per_cpu)
 			 * into some `hv_call_set_vp_registers_raw` function. Then here we could
 			 * call `hv_call_set_vp_registers_raw` to be able to be precise when detecting
 			 * whether the register page is available or not.
+			 *
 			 */
 			pr_info("not using the register page");
 		} else {
@@ -302,9 +305,6 @@ static void mshv_vtl_configure_reg_page(struct mshv_vtl_per_cpu *per_cpu)
 		per_cpu->reg_page = reg_page;
 		mshv_has_reg_page = true;
 	}
-#else
-	pr_debug("not using the register page");
-#endif
 }
 
 #ifdef CONFIG_X86_64

--- a/include/uapi/hyperv/hvgdk_mini.h
+++ b/include/uapi/hyperv/hvgdk_mini.h
@@ -326,7 +326,7 @@ enum hv_interrupt_type {
 	HV_X64_INTERRUPT_TYPE_LOCALINT0		= 0x0008,
 	HV_X64_INTERRUPT_TYPE_LOCALINT1		= 0x0009,
 	HV_X64_INTERRUPT_TYPE_MAXIMUM		= 0x000A,
-#endif	
+#endif
 };
 
 /* Define synthetic interrupt source. */
@@ -652,7 +652,7 @@ struct hv_enable_vp_vtl {
 	union hv_input_vtl		target_vtl;
 	__u8				mbz0;
 	__u16				mbz1;
-#if defined(__x86_64__)	
+#if defined(__x86_64__)
 	struct hv_x64_init_vp_context	vp_context;
 #elif defined(__aarch64__)
 	struct hv_arm64_init_vp_context	vp_context;
@@ -916,7 +916,11 @@ enum hv_register_name {
 	HV_X64_REGISTER_IA32_VMX_TRUE_EXIT_CTLS		= 0x000800B1,
 	HV_X64_REGISTER_IA32_VMX_TRUE_ENTRY_CTLS	= 0x000800B2,
 
-	HV_X64_REGISTER_REG_PAGE	= 0x0009001C,
+#endif
+
+	HV_REGISTER_REG_PAGE	= 0x0009001C,
+
+#if defined(__x86_64__)
 
 	/* Partition Timer Assist Registers */
 	HV_X64_REGISTER_EMULATED_TIMER_PERIOD	= 0x00090030,
@@ -1013,6 +1017,8 @@ enum hv_register_name {
 #define HV_MSR_STIMER0_COUNT	(HV_X64_MSR_STIMER0_COUNT)
 #define HV_MSR_SIMP		(HV_X64_MSR_SIMP)
 #define HV_MSR_SINT0		(HV_X64_MSR_SINT0)
+
+#define HV_X64_REGISTER_REG_PAGE HV_REGISTER_REG_PAGE
 
 #elif defined(__aarch64__)
 


### PR DESCRIPTION
Newer versions of the Hyper-V hypervisor support a register page for VTL transitions on aarch64. If present, make that register page available to userspace.