### PR TITLE
Optimize L1 MSR save/restore

### DIFF
--- a/drivers/hv/Kconfig
+++ b/drivers/hv/Kconfig
@@ -91,6 +91,7 @@ config MSHV_VTL
 	select HYPERV_VTL_MODE
 	select CPUMASK_OFFSTACK
 	select VMAP_PFN
+	select USER_RETURN_NOTIFIER if X86
 	help
 	  Select this option to enable Hyper-V VTL driver.
 	  Virtual Secure Mode (VSM) is a set of hypervisor capabilities and

--- a/drivers/hv/Makefile
+++ b/drivers/hv/Makefile
@@ -18,11 +18,22 @@ CFLAGS_mshv_portid_table.o	= -DHV_HYPERV_DEFS
 CFLAGS_mshv_eventfd.o		= -DHV_HYPERV_DEFS
 CFLAGS_mshv_msi.o			= -DHV_HYPERV_DEFS
 CFLAGS_mshv_vtl_main.o		= -DHV_HYPERV_DEFS
+CFLAGS_mshv_tdx_asm_offsets.o 	= -DHV_HYPERV_DEFS
 
 mshv-y				+= mshv_main.o
 mshv_root-y			:= mshv_root_main.o mshv_synic.o mshv_portid_table.o \
 						mshv_eventfd.o mshv_msi.o mshv_root_hv_call.o hv_call.o
 mshv_vtl-y			:= mshv_vtl_main.o hv_call.o
+
+mshv_vtl-$(CONFIG_X86_64)	+= mshv_tdx.o
+
+$(obj)/mshv_tdx.o: $(obj)/mshv_tdx_asm_offsets.h
+
+$(obj)/mshv_tdx_asm_offsets.h: $(obj)/mshv_tdx_asm_offsets.s FORCE
+	$(call filechk,offsets,__MSHV_TDX_ASM_OFFSETS_H__)
+
+targets += mshv_tdx_asm_offsets.s
+clean-files += mshv_tdx_asm_offsets.h
 
 obj-$(CONFIG_MSHV_XFER_TO_GUEST_WORK) += xfer_to_guest.o
 

--- a/drivers/hv/mshv_tdx.S
+++ b/drivers/hv/mshv_tdx.S
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <asm/asm-offsets.h>
+#include <asm/asm.h>
+#include <asm/tdx.h>
+
+#include <linux/linkage.h>
+#include <linux/errno.h>
+
+#include "mshv_tdx_asm_offsets.h"
+
+.section .noinstr.text, "ax"
+
+#define tdcall          .byte 0x66,0x0f,0x01,0xcc
+#define TDG_VP_ENTER	25
+
+/*
+ * __tdg_vp_enter()  - Make a VP.ENTER TDCALL
+ *
+ * @args (RDI)	- Entry RCX
+ * @args (RSI)	- Entry RDX
+ * @args (RDX)	- struct tdx_tdg_vp_enter_exit_info
+ *
+ * Return status of TDCALL via RAX.
+ */
+SYM_FUNC_START(__tdg_vp_enter)
+
+	push %_ASM_BP
+	_ASM_MOV %_ASM_SP, %_ASM_BP
+
+	movq	$TDG_VP_ENTER, %rax
+	movq	%rdi, %rcx
+/* Swap 2nd and 3rd args so RDX will contain entry RDX value and RSI will point
+ * to tdx_tdg_vp_enter_exit_info */
+	xchg	%rsi, %rdx
+
+        push	%rbx
+        push	%r8
+        push	%r9
+        push	%r10
+        push	%r11
+        push	%r12
+        push	%r13
+        push	%r14
+        push	%r15
+
+	/* r8 - r15 needs to cleared before VP.ENTER */
+        xor	%r8, %r8
+        xor	%r9, %r9
+        xor	%r10, %r10
+        xor	%r11, %r11
+        xor	%r12, %r12
+        xor	%r13, %r13
+        xor	%r14, %r14
+        xor	%r15, %r15
+
+/* Save the pointer to tdx_tdg_vp_enter_exit_info */
+	push	%rsi
+
+	tdcall
+
+/* Store the exit RSI value before restoring RSI with pointer to
+ * tdx_tdg_vp_enter_exit_info */
+	push	%rax
+	movq	8(%rsp), %rax
+	movq	%rsi, TDX_TDG_EXIT_INFO_rsi(%rax)
+	pop	%rax
+	pop	%rsi
+
+	movq	%rax, TDX_TDG_EXIT_INFO_rax(%rsi)
+	movq	%rcx, TDX_TDG_EXIT_INFO_rcx(%rsi)
+	movq	%rdx, TDX_TDG_EXIT_INFO_rdx(%rsi)
+	movq	%rdi, TDX_TDG_EXIT_INFO_rdi(%rsi)
+	movq	%r8, TDX_TDG_EXIT_INFO_r8(%rsi)
+	movq	%r9, TDX_TDG_EXIT_INFO_r9(%rsi)
+	movq	%r10, TDX_TDG_EXIT_INFO_r10(%rsi)
+	movq	%r11, TDX_TDG_EXIT_INFO_r11(%rsi)
+	movq	%r12, TDX_TDG_EXIT_INFO_r12(%rsi)
+	movq	%r13, TDX_TDG_EXIT_INFO_r13(%rsi)
+
+/* Following will scrub the registers */
+        pop	%r15
+        pop	%r14
+        pop	%r13
+        pop	%r12
+        pop	%r11
+        pop	%r10
+        pop	%r9
+        pop	%r8
+        pop	%rbx
+
+        pop %_ASM_BP
+	RET
+
+SYM_FUNC_END(__tdg_vp_enter)

--- a/drivers/hv/mshv_tdx_asm_offsets.c
+++ b/drivers/hv/mshv_tdx_asm_offsets.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Generate definitions needed by assembly language modules.
+ * This code generates raw asm output which is post-processed to extract
+ * and format the required data.
+ */
+#define COMPILE_OFFSETS
+
+#include <linux/kbuild.h>
+#include "mshv_vtl.h"
+
+static void __used common(void)
+{
+	BLANK();
+	OFFSET(TDX_TDG_EXIT_INFO_rax, tdx_tdg_vp_enter_exit_info, rax);
+	OFFSET(TDX_TDG_EXIT_INFO_rcx, tdx_tdg_vp_enter_exit_info, rcx);
+	OFFSET(TDX_TDG_EXIT_INFO_rdx, tdx_tdg_vp_enter_exit_info, rdx);
+	OFFSET(TDX_TDG_EXIT_INFO_rsi, tdx_tdg_vp_enter_exit_info, rsi);
+	OFFSET(TDX_TDG_EXIT_INFO_rdi, tdx_tdg_vp_enter_exit_info, rdi);
+	OFFSET(TDX_TDG_EXIT_INFO_r8, tdx_tdg_vp_enter_exit_info, r8);
+	OFFSET(TDX_TDG_EXIT_INFO_r9, tdx_tdg_vp_enter_exit_info, r9);
+	OFFSET(TDX_TDG_EXIT_INFO_r10, tdx_tdg_vp_enter_exit_info, r10);
+	OFFSET(TDX_TDG_EXIT_INFO_r11, tdx_tdg_vp_enter_exit_info, r11);
+	OFFSET(TDX_TDG_EXIT_INFO_r12, tdx_tdg_vp_enter_exit_info, r12);
+	OFFSET(TDX_TDG_EXIT_INFO_r13, tdx_tdg_vp_enter_exit_info, r13);
+}

--- a/drivers/hv/mshv_vtl.h
+++ b/drivers/hv/mshv_vtl.h
@@ -2,6 +2,7 @@
 #ifndef _MSHV_VTL_H
 #define _MSHV_VTL_H
 
+#include <linux/kernel.h>
 #include <linux/mshv.h>
 #include <linux/types.h>
 #include <asm/mshyperv.h>
@@ -151,6 +152,8 @@ struct mshv_vtl_run {
 
 #ifdef CONFIG_X86_64
 static_assert(offsetof(struct mshv_vtl_run, tdx_context) == 272);
+u64 __tdg_vp_enter(u64 rcx, u64 rdx,
+		struct tdx_tdg_vp_enter_exit_info *tdg_exit_info);
 #endif
 
 static_assert(sizeof(struct mshv_vtl_run) <= 4096);
@@ -158,8 +161,5 @@ static_assert(sizeof(struct mshv_vtl_run) <= 4096);
 #define SEV_GHCB_VERSION        1
 #define SEV_GHCB_FORMAT_BASE        0
 #define SEV_GHCB_FORMAT_VTL_RETURN  2
-
-/* TDCALL Instruction Leaf Numbers */
-#define TDG_VP_ENTER 25
 
 #endif /* _MSHV_VTL_H */

--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -814,34 +814,17 @@ void mshv_tdx_request_cache_flush(bool wbnoinvd)
 	__tdx_hypercall(&args);
 }
 
-#define TDCALL_ASM	".byte 0x66,0x0f,0x01,0xcc"
-
-/* TODO TDX: Confirm noinline produces the right asm for saving register state */
-noinline void mshv_vtl_return_tdx(void)
+void mshv_vtl_return_tdx(void)
 {
 	struct tdx_tdg_vp_enter_exit_info *tdx_exit_info;
 	struct tdx_vp_state *tdx_vp_state;
 	struct mshv_vtl_run *vtl_run;
 	struct mshv_vtl_per_cpu *per_cpu;
 
-	register void *__sp asm("rsp");
-	register u64 r8 asm("r8");
-	register u64 r9 asm("r9");
-	register u64 r10 asm("r10");
-	register u64 r11 asm("r11");
-	register u64 r12 asm("r12");
-	register u64 r13 asm("r13");
-	register u64 r14 asm("r14");
-	register u64 r15 asm("r15");
-
 	vtl_run = mshv_vtl_this_run();
 	tdx_exit_info = &vtl_run->tdx_context.exit_info;
 	tdx_vp_state = &vtl_run->tdx_context.vp_state;
 	per_cpu = this_cpu_ptr(&mshv_vtl_per_cpu);
-
-	u64 input_rax = TDG_VP_ENTER;
-	u64 input_rcx = vtl_run->tdx_context.entry_rcx;
-	u64 input_rdx = virt_to_phys((void*) &vtl_run->tdx_context.l2_enter_guest_state);
 
 	/*
 	 * TODO TDX: KVM has some code and paths that seem like there is a way to
@@ -865,39 +848,10 @@ noinline void mshv_vtl_return_tdx(void)
 	if (tdx_vp_state->msr_xss != per_cpu->xss)
 		wrmsrl(MSR_IA32_XSS, tdx_vp_state->msr_xss);
 
-	r8 = 0;
-	r9 = 0;
-	r10 = 0;
-	r11 = 0;
-	r12 = 0;
-	r13 = 0;
-	r14 = 0;
-	r15 = 0;
+	__tdg_vp_enter(vtl_run->tdx_context.entry_rcx,
+			virt_to_phys((void *) &vtl_run->tdx_context.l2_enter_guest_state),
+			tdx_exit_info);
 
-	/*
-	 * TODO TDX: pushq popq causes some build complaints unclear why when
-	 * mshv uses it also. Alignment checks even though tdcall has no alignment reqs?
-	 */
-	asm __volatile__ (\
-		/* Save RBP onto the stack since it'll be clobbered and inline asm won't save it. */
-		"pushq	%%rbp\n"
-		TDCALL_ASM "\n"
-		/* restore rbp from the stack */
-		"popq	%%rbp\n"
-		: "=a"(tdx_exit_info->rax), "=c"(tdx_exit_info->rcx),
-		  "=d"(tdx_exit_info->rdx), "=S"(tdx_exit_info->rsi), "=D"(tdx_exit_info->rdi),
-		  "=r" (r8), "=r" (r9), "=r" (r10), "=r" (r11), "=r"(r12), "=r"(r13), "=r"(r14),
-		  "=r"(r15), "+r" (__sp)
-		: "a"(input_rax), "c"(input_rcx), "d"(input_rdx)
-		: "rbx", "cc", "memory" /* TODO: is the "cc" necessary? */
-	);
-
-	tdx_exit_info->r8 = r8;
-	tdx_exit_info->r9 = r9;
-	tdx_exit_info->r10 = r10;
-	tdx_exit_info->r11 = r11;
-	tdx_exit_info->r12 = r12;
-	tdx_exit_info->r13 = r13;
 	tdx_vp_state->cr2 = native_read_cr2();
 	rdmsrl(MSR_IA32_XSS, tdx_vp_state->msr_xss);
 	per_cpu->xss = tdx_vp_state->msr_xss;

--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -19,6 +19,7 @@
 #include <linux/eventfd.h>
 #include <linux/poll.h>
 #include <linux/file.h>
+#include <linux/user-return-notifier.h>
 #include <linux/vmalloc.h>
 #include <asm/boot.h>
 #include <asm/trace/hyperv.h>
@@ -161,6 +162,8 @@ struct mshv_vtl_per_cpu {
 	u64 l1_msr_lstar;
 	u64 l1_msr_sfmask;
 	u64 l1_msr_tsc_aux;
+	bool urn_registered;
+	struct user_return_notifier mshv_urn;
 #endif
 };
 
@@ -608,12 +611,13 @@ static int mshv_vtl_alloc_context(unsigned int cpu)
 
 		/*
 		 * Capture the initial syscall MSRs to be restored after VP.ENTER.
-		 * TODO TDX: Needs review from kernel experts.
 		 */
 		rdmsrl(MSR_KERNEL_GS_BASE, per_cpu->l1_msr_kernel_gs_base);
 		rdmsrl(MSR_STAR, per_cpu->l1_msr_star);
 		rdmsrl(MSR_LSTAR, per_cpu->l1_msr_lstar);
 		rdmsrl(MSR_SYSCALL_MASK, per_cpu->l1_msr_sfmask);
+
+		per_cpu->urn_registered = false;
 
 		/* Enable the apic page. */
 		mshv_write_tdx_apic_page(page_to_phys(tdx_apic_page));
@@ -814,6 +818,21 @@ void mshv_tdx_request_cache_flush(bool wbnoinvd)
 	__tdx_hypercall(&args);
 }
 
+static void mshv_vtl_on_user_return(struct user_return_notifier *urn)
+{
+	struct mshv_vtl_per_cpu *per_cpu
+		= container_of(urn, struct mshv_vtl_per_cpu, mshv_urn);
+
+	per_cpu->urn_registered = false;
+	user_return_notifier_unregister(urn);
+
+	wrmsrl(MSR_KERNEL_GS_BASE, per_cpu->l1_msr_kernel_gs_base);
+	wrmsrl(MSR_STAR, per_cpu->l1_msr_star);
+	wrmsrl(MSR_LSTAR, per_cpu->l1_msr_lstar);
+	wrmsrl(MSR_SYSCALL_MASK, per_cpu->l1_msr_sfmask);
+	wrmsrl(MSR_TSC_AUX, per_cpu->l1_msr_tsc_aux);
+}
+
 void mshv_vtl_return_tdx(void)
 {
 	struct tdx_tdg_vp_enter_exit_info *tdx_exit_info;
@@ -826,12 +845,6 @@ void mshv_vtl_return_tdx(void)
 	tdx_vp_state = &vtl_run->tdx_context.vp_state;
 	per_cpu = this_cpu_ptr(&mshv_vtl_per_cpu);
 
-	/*
-	 * TODO TDX: KVM has some code and paths that seem like there is a way to
-	 * defer TSC_AUX saving until usermode starts. For now, save/restore VTL2's
-	 * view of TSC_AUX across every VP.ENTER call until we can do the same
-	 * thing.
-	*/
 	rdmsrl(MSR_TSC_AUX, per_cpu->l1_msr_tsc_aux);
 
 	kernel_fpu_begin_mask(0);
@@ -862,12 +875,11 @@ void mshv_vtl_return_tdx(void)
 	rdmsrl(MSR_SYSCALL_MASK, tdx_vp_state->msr_sfmask);
 	rdmsrl(MSR_TSC_AUX, tdx_vp_state->msr_tsc_aux);
 
-	/* Restore VTL2's syscall registers & MSRs */
-	wrmsrl(MSR_KERNEL_GS_BASE, per_cpu->l1_msr_kernel_gs_base);
-	wrmsrl(MSR_STAR, per_cpu->l1_msr_star);
-	wrmsrl(MSR_LSTAR, per_cpu->l1_msr_lstar);
-	wrmsrl(MSR_SYSCALL_MASK, per_cpu->l1_msr_sfmask);
-	wrmsrl(MSR_TSC_AUX, per_cpu->l1_msr_tsc_aux);
+	if (!per_cpu->urn_registered) {
+		per_cpu->mshv_urn.on_user_return = mshv_vtl_on_user_return;
+		user_return_notifier_register(&per_cpu->mshv_urn);
+		per_cpu->urn_registered = true;
+	}
 
 	fxsave(&vtl_run->tdx_context.fx_state);
 	kernel_fpu_end();


### PR DESCRIPTION
Defer restoring L1 MSRs until there is a switch to user mode where the MSRs are used. This avoids unnecessary write to those MSRs if there was a switch to L2 guest while L1 is still in kernel mode.

This commit is applied over "mshv_vtl/tdx: Add assembly function for TDG.VP.ENTER" which has not been merged yet to avoid merge conflicts later when it is applied. Please merge https://github.com/microsoft/OHCL-Linux-Kernel/pull/54 first and ignore the TDG.VP.ENTER related commit in this PR.