### PR TITLE
x86/hyperv: Run the linear scan for the cpu number only when needed

### DIFF
--- a/arch/x86/coco/sev/core.c
+++ b/arch/x86/coco/sev/core.c
@@ -1097,16 +1097,23 @@ static void snp_cleanup_vmsa(struct sev_es_save_area *vmsa, int apic_id)
 		free_page((unsigned long)vmsa);
 }
 
-static int wakeup_cpu_via_vmgexit(u32 apic_id, unsigned long start_ip)
+static int wakeup_cpu_via_vmgexit(struct wakeup_secondary_cpu_data *wakeup)
 {
 	struct sev_es_save_area *cur_vmsa, *vmsa;
 	struct ghcb_state state;
+	unsigned long start_ip;
 	struct svsm_ca *caa;
 	unsigned long flags;
 	struct ghcb *ghcb;
 	u8 sipi_vector;
 	int cpu, ret;
+	u32 apic_id;
 	u64 cr4;
+
+
+	cpu = wakeup->cpu;
+	apic_id = wakeup->apicid;
+	start_ip = wakeup->start_ip;
 
 	/*
 	 * The hypervisor SNP feature support check has happened earlier, just check
@@ -1126,15 +1133,6 @@ static int wakeup_cpu_via_vmgexit(u32 apic_id, unsigned long start_ip)
 
 	/* Override start_ip with known protected guest start IP */
 	start_ip = real_mode_header->sev_es_trampoline_start;
-
-	/* Find the logical CPU for the APIC ID */
-	for_each_present_cpu(cpu) {
-		if (arch_match_cpu_phys_id(cpu, apic_id))
-			break;
-	}
-	if (cpu >= nr_cpu_ids)
-		return -EINVAL;
-
 	cur_vmsa = per_cpu(sev_vmsa, cpu);
 
 	/*

--- a/arch/x86/hyperv/hv_vtl.c
+++ b/arch/x86/hyperv/hv_vtl.c
@@ -371,17 +371,14 @@ int hv_vtl_apicid_to_vp_id(u32 apic_id)
 	return ret;
 }
 
-static int hv_vtl_wakeup_secondary_cpu(u32 apicid, unsigned long start_eip)
+static int hv_vtl_wakeup_secondary_cpu(struct wakeup_secondary_cpu_data *wakeup)
 {
-	int vp_id, cpu;
-
-	/* Find the logical CPU for the APIC ID */
-	for_each_present_cpu(cpu) {
-		if (arch_match_cpu_phys_id(cpu, apicid))
-			break;
-	}
-	if (cpu >= nr_cpu_ids)
-		return -EINVAL;
+	unsigned long start_ip;
+	u32 apicid;
+	int vp_id;
+	
+	apicid = wakeup->apicid;
+	start_ip = wakeup->start_ip;
 
 	pr_debug("Bringing up CPU with APIC ID %d in VTL2...\n", apicid);
 	/*
@@ -401,9 +398,9 @@ static int hv_vtl_wakeup_secondary_cpu(u32 apicid, unsigned long start_eip)
 	}
 
 	if (hv_isolation_type_tdx())
-		return hv_vtl_bringup_tdx_vcpu(vp_id, start_eip);
+		return hv_vtl_bringup_tdx_vcpu(vp_id, start_ip);
 	else
-		return hv_vtl_bringup_vcpu(vp_id, cpu, start_eip);
+		return hv_vtl_bringup_vcpu(vp_id, wakeup->cpu, start_ip);
 }
 
 int __init hv_vtl_early_init(void)

--- a/arch/x86/hyperv/ivm.c
+++ b/arch/x86/hyperv/ivm.c
@@ -10,6 +10,7 @@
 #include <linux/hyperv.h>
 #include <linux/types.h>
 #include <linux/slab.h>
+#include <asm/apic.h>
 #include <asm/svm.h>
 #include <asm/sev.h>
 #include <asm/io.h>
@@ -289,38 +290,28 @@ static void snp_cleanup_vmsa(struct sev_es_save_area *vmsa)
 		free_page((unsigned long)vmsa);
 }
 
-int hv_snp_boot_ap(u32 apic_id, unsigned long start_ip)
+int hv_snp_boot_ap(struct wakeup_secondary_cpu_data *wakeup)
 {
 	struct sev_es_save_area *vmsa = (struct sev_es_save_area *)
 		__get_free_page(GFP_KERNEL | __GFP_ZERO);
 	struct sev_es_save_area *cur_vmsa;
 	struct desc_ptr gdtr;
 	struct hv_enable_vp_vtl *start_vp_input;
-	int cpu_id = -EINVAL;
 	unsigned long flags;
 	u64 ret, retry = 5;
-	int vp_id = apic_id;
+	u32 apic_id;
+	int vp_id;
+	int cpu_id;
 
 	if (!vmsa)
 		return -ENOMEM;
 
-#ifdef CONFIG_HYPERV_VTL_MODE
-	int i;
-
-	for_each_possible_cpu(i) {
-		if (per_cpu(x86_cpu_to_apicid, i) == apic_id) {
-			cpu_id = i;
-			break;
-		}
-	}
-
-	if (cpu_id == -EINVAL)
-		panic("%s: no cpu found for APIC ID %d\n", __func__, apic_id);
+	cpu_id = wakeup->cpu;
+	apic_id = wakeup->apicid;
 
 	vp_id = hv_vtl_apicid_to_vp_id(apic_id);
-	if (vp_id < 0)
+	if (vp_id < 0 || vp_id > ms_hyperv.max_vp_index)
 		panic("%s: error when getting VP id for APIC id %#x\n", __func__, apic_id);
-#endif
 
 	native_store_gdt(&gdtr);
 
@@ -372,20 +363,6 @@ int hv_snp_boot_ap(u32 apic_id, unsigned long start_ip)
 	start_vp_input->vp_index = vp_id;
 	start_vp_input->target_vtl.target_vtl = ms_hyperv.vtl;
 	*(u64 *)&start_vp_input->vp_context = __pa(vmsa) | 1;
-
-#ifdef CONFIG_HYPERV_VTL_MODE
-	if (ms_hyperv.vtl != 0) {
-		do {
-			ret = hv_do_hypercall(HVCALL_ENABLE_VP_VTL,
-					      start_vp_input, NULL);
-		} while (hv_result(ret) == HV_STATUS_TIME_OUT && retry--);
-
-		if (ret) {
-			pr_err("HvCallEnableVpVtl failed: %llx\n", ret);
-			return ret;
-		}
-	}
-#endif
 
 	do {
 		ret = hv_do_hypercall(HVCALL_START_VP,

--- a/arch/x86/include/asm/apic.h
+++ b/arch/x86/include/asm/apic.h
@@ -262,6 +262,12 @@ extern void __init check_x2apic(void);
 
 struct irq_data;
 
+struct wakeup_secondary_cpu_data {
+	int cpu;
+	u32 apicid;
+	unsigned long start_ip;
+};
+
 /*
  * Copyright 2004 James Cleverdon, IBM.
  *
@@ -313,9 +319,9 @@ struct apic {
 	u32	(*get_apic_id)(u32 id);
 
 	/* wakeup_secondary_cpu */
-	int	(*wakeup_secondary_cpu)(u32 apicid, unsigned long start_eip);
+	int	(*wakeup_secondary_cpu)(struct wakeup_secondary_cpu_data *data);
 	/* wakeup secondary CPU using 64-bit wakeup point */
-	int	(*wakeup_secondary_cpu_64)(u32 apicid, unsigned long start_eip);
+	int	(*wakeup_secondary_cpu_64)(struct wakeup_secondary_cpu_data *data);
 
 	char	*name;
 };
@@ -333,8 +339,8 @@ struct apic_override {
 	void	(*send_IPI_self)(int vector);
 	u64	(*icr_read)(void);
 	void	(*icr_write)(u32 low, u32 high);
-	int	(*wakeup_secondary_cpu)(u32 apicid, unsigned long start_eip);
-	int	(*wakeup_secondary_cpu_64)(u32 apicid, unsigned long start_eip);
+	int	(*wakeup_secondary_cpu)(struct wakeup_secondary_cpu_data *data);
+	int	(*wakeup_secondary_cpu_64)(struct wakeup_secondary_cpu_data *data);
 };
 
 /*

--- a/arch/x86/include/asm/mshyperv.h
+++ b/arch/x86/include/asm/mshyperv.h
@@ -6,6 +6,7 @@
 #include <linux/nmi.h>
 #include <linux/msi.h>
 #include <linux/io.h>
+#include <asm/apic.h>
 #include <asm/nospec-branch.h>
 #include <asm/paravirt.h>
 #include <asm/tdx.h>
@@ -264,11 +265,11 @@ int hv_unmap_ioapic_interrupt(int ioapic_id, struct hv_interrupt_entry *entry);
 #ifdef CONFIG_AMD_MEM_ENCRYPT
 bool hv_ghcb_negotiate_protocol(void);
 void __noreturn hv_ghcb_terminate(unsigned int set, unsigned int reason);
-int hv_snp_boot_ap(u32 cpu, unsigned long start_ip);
+int hv_snp_boot_ap(struct wakeup_secondary_cpu_data *wakeup);
 #else
 static inline bool hv_ghcb_negotiate_protocol(void) { return false; }
 static inline void hv_ghcb_terminate(unsigned int set, unsigned int reason) {}
-static inline int hv_snp_boot_ap(u32 cpu, unsigned long start_ip) { return 0; }
+static inline int hv_snp_boot_ap(struct wakeup_secondary_cpu_data *wakeup) { return 0; }
 #endif
 
 #if defined(CONFIG_AMD_MEM_ENCRYPT) || defined(CONFIG_INTEL_TDX_GUEST)

--- a/arch/x86/kernel/acpi/madt_wakeup.c
+++ b/arch/x86/kernel/acpi/madt_wakeup.c
@@ -169,8 +169,14 @@ static int __init acpi_mp_setup_reset(u64 reset_vector)
 	return 0;
 }
 
-static int acpi_wakeup_cpu(u32 apicid, unsigned long start_ip)
+static int acpi_wakeup_cpu(struct wakeup_secondary_cpu_data *wakeup)
 {
+	unsigned long start_ip;
+	u32 apicid;
+
+	start_ip = wakeup->start_ip;
+	apicid = wakeup->apicid;
+
 	if (!acpi_mp_wake_mailbox_paddr) {
 		pr_warn_once("No MADT mailbox: cannot bringup secondary CPUs. Booting with kexec?\n");
 		return -EOPNOTSUPP;

--- a/arch/x86/kernel/apic/apic_noop.c
+++ b/arch/x86/kernel/apic/apic_noop.c
@@ -27,7 +27,7 @@ static void noop_send_IPI_allbutself(int vector) { }
 static void noop_send_IPI_all(int vector) { }
 static void noop_send_IPI_self(int vector) { }
 static void noop_apic_icr_write(u32 low, u32 id) { }
-static int noop_wakeup_secondary_cpu(u32 apicid, unsigned long start_eip) { return -1; }
+static int noop_wakeup_secondary_cpu(struct wakeup_secondary_cpu_data *data) { return -1; }
 static u64 noop_apic_icr_read(void) { return 0; }
 static u32 noop_get_apic_id(u32 apicid) { return 0; }
 static void noop_apic_eoi(void) { }

--- a/arch/x86/kernel/apic/x2apic_uv_x.c
+++ b/arch/x86/kernel/apic/x2apic_uv_x.c
@@ -667,10 +667,15 @@ static __init void build_uv_gr_table(void)
 	}
 }
 
-static int uv_wakeup_secondary(u32 phys_apicid, unsigned long start_rip)
+static int uv_wakeup_secondary(struct wakeup_secondary_cpu_data *wakeup)
 {
+	unsigned long start_rip;
 	unsigned long val;
+	u32 phys_apicid;
 	int pnode;
+
+	phys_apicid = wakeup->apicid;
+	start_rip = wakeup->start_ip;
 
 	pnode = uv_apicid_to_pnode(phys_apicid);
 

--- a/arch/x86/kernel/smpboot.c
+++ b/arch/x86/kernel/smpboot.c
@@ -728,8 +728,14 @@ static void send_init_sequence(u32 phys_apicid)
 /*
  * Wake up AP by INIT, INIT, STARTUP sequence.
  */
-static int wakeup_secondary_cpu_via_init(u32 phys_apicid, unsigned long start_eip)
+static int wakeup_secondary_cpu_via_init(struct wakeup_secondary_cpu_data *wakeup)
 {
+	unsigned long start_eip;
+	u32 phys_apicid;
+
+	start_eip = wakeup->start_ip;
+	phys_apicid = wakeup->apicid;
+
 	unsigned long send_status = 0, accept_status = 0;
 	int num_starts, j, maxlvt;
 
@@ -878,6 +884,7 @@ int common_cpu_up(unsigned int cpu, struct task_struct *idle)
 static int do_boot_cpu(u32 apicid, int cpu, struct task_struct *idle)
 {
 	unsigned long start_ip = real_mode_header->trampoline_start;
+	struct wakeup_secondary_cpu_data wakeup;
 	int ret;
 
 #ifdef CONFIG_X86_64
@@ -921,6 +928,10 @@ static int do_boot_cpu(u32 apicid, int cpu, struct task_struct *idle)
 
 	smp_mb();
 
+	wakeup.cpu = cpu;
+	wakeup.apicid = apicid;
+	wakeup.start_ip = start_ip;
+
 	/*
 	 * Wake up a CPU in difference cases:
 	 * - Use a method from the APIC driver if one defined, with wakeup
@@ -929,11 +940,11 @@ static int do_boot_cpu(u32 apicid, int cpu, struct task_struct *idle)
 	 * - Use an INIT boot APIC message
 	 */
 	if (apic->wakeup_secondary_cpu_64)
-		ret = apic->wakeup_secondary_cpu_64(apicid, start_ip);
+		ret = apic->wakeup_secondary_cpu_64(&wakeup);
 	else if (apic->wakeup_secondary_cpu)
-		ret = apic->wakeup_secondary_cpu(apicid, start_ip);
+		ret = apic->wakeup_secondary_cpu(&wakeup);
 	else
-		ret = wakeup_secondary_cpu_via_init(apicid, start_ip);
+		ret = wakeup_secondary_cpu_via_init(&wakeup);
 
 	/* If the wakeup mechanism failed, cleanup the warm reset vector */
 	if (ret)


### PR DESCRIPTION
The code in question needs to know the CPU number, and that requires a linear scan which results in O(n^2) complexity for n VPs.

Run it only in the pathological case and don't run in the TDX case at all to potentially improve performance.