### PR TITLE
drivers/hv: use dedicated mshv_vtl_sidecar irq

### DIFF
--- a/drivers/hv/mshv.h
+++ b/drivers/hv/mshv.h
@@ -123,11 +123,9 @@ int mshv_setup_vtl_func(const mshv_create_func_t create_vtl,
 int mshv_set_create_partition_func(const mshv_create_func_t func, struct device **dev);
 
 #ifdef CONFIG_X86_64
-void mshv_vtl_sidecar_isr(void);
 int __init mshv_vtl_sidecar_init(void);
 void mshv_vtl_sidecar_exit(void);
 #else
-static inline void mshv_vtl_sidecar_isr(void) {}
 static inline int mshv_vtl_sidecar_init(void) { return 0; }
 static inline void mshv_vtl_sidecar_exit(void) {}
 #endif

--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -515,7 +515,6 @@ static void mshv_vtl_vmbus_isr(void)
 		}
 	}
 
-	mshv_vtl_sidecar_isr();
 	vmbus_isr();
 }
 

--- a/drivers/hv/mshv_vtl_sidecar.c
+++ b/drivers/hv/mshv_vtl_sidecar.c
@@ -11,6 +11,7 @@
 #include <uapi/linux/mshv.h>
 #include <asm/apic.h>
 #include <asm/irq_vectors.h>
+#include <asm/irq.h>
 
 #include "mshv.h"
 
@@ -62,7 +63,7 @@ DEFINE_PER_CPU(struct sidecar_dev *, sidecar_interrupt_dev);
 #define VP_STATE_ASYNC_STOPPED 4
 #define VP_STATE_REMOVED 0xff
 
-void mshv_vtl_sidecar_isr(void)
+static void mshv_vtl_sidecar_isr(void)
 {
 	struct sidecar_dev *dev;
 
@@ -437,15 +438,29 @@ static int sidecar_probe(struct platform_device *pdev)
 	resource_size_t total_shmem_size;
 	struct sidecar_dev *dev;
 	char name[64];
-	static bool registered_cpuhp;
+	static bool global_init;
 
-	if (!registered_cpuhp) {
+	if (!global_init) {
+		/*
+		 * Use the platform IPI callback for IPIs from sidecar; this vector
+		 * won't be used by anything else in a VTL2 environment.
+		 *
+		 * We can't use the hypervisor callback vector because it may be
+		 * configured to use auto EOI, and there is no interface to send
+		 * auto-EOI IPIs.
+		 */
+		if (x86_platform_ipi_callback) {
+			pr_err("x86_platform_ipi_callback already set\n");
+			return -EBUSY;
+		}
+
 		ret = cpuhp_setup_state(CPUHP_BP_PREPARE_DYN, "mshv_vtl_sidecar:remove_for_hotplug",
 				sidecar_remove, NULL);
 		if (ret < 0)
 			return ret;
 
-		registered_cpuhp = true;
+		x86_platform_ipi_callback = mshv_vtl_sidecar_isr;
+		global_init = true;
 	}
 
 	dev = devm_kzalloc(&pdev->dev, sizeof(*dev), GFP_KERNEL);
@@ -499,7 +514,7 @@ static int sidecar_probe(struct platform_device *pdev)
 	}
 
 	dev->control->response_cpu = per_cpu(x86_cpu_to_apicid, dev->base_cpu);
-	dev->control->response_vector = HYPERVISOR_CALLBACK_VECTOR;
+	dev->control->response_vector = X86_PLATFORM_IPI_VECTOR;
 	per_cpu(sidecar_interrupt_dev, dev->base_cpu) = dev;
 
 	dev->misc = sidecar_misc;


### PR DESCRIPTION
Currently, the sidecar kernel driver uses the hypervisor callback vector to receive signals from the sidecar kernel. This vector is shared by SINT users (e.g., vmbus).

This breaks down when the SINTs are configured to use auto EOI. This happens when the hypervisor determines that auto EOI is more efficient than standard EOI on the platform; this can happen when running with nested virtualization, for example. In this case, the ISR will expect that auto EOI occurred and will skip the explicit EOI.

However, the sidecar kernel will not, and has no mechanism to, signal an interrupt with auto EOI. So when the sidecar sends an interrupt, the vector will remain set in the APIC ISR, and no further interrupts will be signaled by either the hypervisor or the sidecar kernel.

To fix this, use the platform IPI vector for IPIs from the sidecar kernel.  This allows the SINTs to continue to use auto EOI while allowing the sidecar kernel to function.