### PR TITLE
ci: upload artifacts even if not publishing a release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,6 @@ jobs:
           make $makeargs -j$(nproc) $targets
 
       - name: Prepare for packaging
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           export artifacts_dir="release_artifacts/${{ matrix.arch }}"
           if [ "${{ matrix.arch }}" == "arm64" ]; then
@@ -80,7 +79,6 @@ jobs:
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           name: ${{ matrix.arch }}-build
           path: release_artifacts/${{ matrix.arch }}/


### PR DESCRIPTION
This makes it possible to download an artifact for testing.