### PR TITLE
(DO NOT MERGE: WILL UPSTREAM THIS CHANGE FIRST) get connection-id from device tree

### DIFF
--- a/drivers/hv/connection.c
+++ b/drivers/hv/connection.c
@@ -71,15 +71,7 @@ module_param(max_version, uint, S_IRUGO);
 MODULE_PARM_DESC(max_version,
 		 "Maximal VMBus protocol version which can be negotiated");
 
-/*
- * User requested connection id used to connect to the host. Useful for testing
- * or when running a vmbus server on a non-standard connection id.
- */
-static uint message_connection_id;
-
-module_param(message_connection_id, uint, 0444);
-MODULE_PARM_DESC(message_connection_id,
-		 "The VMBus message connection id used to communicate with the Host");
+/* Connection ID is now provided via device tree */
 
 int vmbus_negotiate_version(struct vmbus_channel_msginfo *msginfo, u32 version)
 {
@@ -109,14 +101,14 @@ int vmbus_negotiate_version(struct vmbus_channel_msginfo *msginfo, u32 version)
 	if (version >= VERSION_WIN10_V5) {
 		msg->msg_sint = VMBUS_MESSAGE_SINT;
 		msg->msg_vtl = ms_hyperv.vtl;
-		vmbus_connection.msg_conn_id = VMBUS_MESSAGE_CONNECTION_ID_4;
 	} else {
 		msg->interrupt_page = virt_to_phys(vmbus_connection.int_page);
-		vmbus_connection.msg_conn_id = VMBUS_MESSAGE_CONNECTION_ID;
 	}
 
-	if (message_connection_id > 0)
-		vmbus_connection.msg_conn_id = message_connection_id;
+	/* Set default connection ID if not provided via device tree */
+	if (!vmbus_connection.msg_conn_id)
+		vmbus_connection.msg_conn_id = (version >= VERSION_WIN10_V5) ?
+			VMBUS_MESSAGE_CONNECTION_ID_4 : VMBUS_MESSAGE_CONNECTION_ID;
 
 	/*
 	 * shared_gpa_boundary is zero in non-SNP VMs, so it's safe to always

--- a/drivers/hv/vmbus_drv.c
+++ b/drivers/hv/vmbus_drv.c
@@ -2345,11 +2345,19 @@ static int vmbus_device_add(struct platform_device *pdev)
 	struct of_range range;
 	struct of_range_parser parser;
 	struct device_node *np = pdev->dev.of_node;
+	unsigned int conn_id;
 	int ret;
 
 	pr_info("VMBus is present in DeviceTree\n");
 
 	vmbus_root_device = &pdev->dev;
+
+	/* Read connection ID from device tree */
+	ret = of_property_read_u32(np, "microsoft,message-connection-id", &conn_id);
+	if (!ret) {
+		pr_info("VMBus message connection ID: %u\n", conn_id);
+		vmbus_connection.msg_conn_id = conn_id;
+	}
 
 	ret = of_range_parser_init(&parser, np);
 	if (ret)


### PR DESCRIPTION
The connection-id determines which hypervisor communication channel the guest should use to talk to the VMBus host. Get this value from device tree instead of kernel boot arguments.

Below data shows already existing property under the vmbus device tree node with the compatible id "microsoft,message-connection-id":
# cd /sys/firmware/devicetree/base/bus/vmbus
/sys/firmware/devicetree/base/bus/vmbus # hexdump microsoft,message-connection-i
d
0000000 8000 7400
0000004

connection-id value from dmesg logs after the code change:
0.630151] hv_vmbus: VMBus message connection ID: 8388724

The hexdump shows: 00 80 00 74
0x00800074 = 8388724 (decimal)