### PR TITLE
drivers/hv/mshv_vtl: fix wait on sidecar CPU online

### DIFF
--- a/drivers/hv/mshv_vtl_sidecar.c
+++ b/drivers/hv/mshv_vtl_sidecar.c
@@ -147,13 +147,14 @@ static int sidecar_remove(unsigned int cpu)
 		return 0;
 	}
 
-	dev_info(dev->dev, "removing sidecar cpu %d", cpu);
+	dev_info(dev->dev, "cpu %d: removing from sidecar", cpu);
 	slot = &dev->control->cpu_status[cpu_index];
 	last = cmpxchg(slot, CPU_STATUS_IDLE, CPU_STATUS_REMOVE);
 	WARN(last != CPU_STATUS_IDLE, "unexpected cpu status %d", last);
 
 	sidecar_signal(dev, cpu);
-	wait_event(dev->wait, READ_ONCE(*slot) == CPU_STATUS_REMOVE);
+	wait_event(dev->wait, READ_ONCE(*slot) == CPU_STATUS_IDLE);
+	dev_info(dev->dev, "cpu %d: remove complete", cpu);
 	last = READ_ONCE(dev->vp_state[cpu_index]);
 	WARN(last != VP_STATE_REMOVED, "unexpected vp state %d", last);
 	return 0;


### PR DESCRIPTION
The sidecar driver's CPU online path tries to wait for the sidecar kernel to finish deinitializing the CPU before it allows the kernel to online it. However, the wait condition is wrong, causing the wait to be ineffective when the sidecar kernel is slow and causing hangs when the sidecar kernel is fast.

Fix the wait condition. Add a log entry as well for better diagnostics.