### PR TITLE
drivers/hv/mshv_vtl: fix wait condition again

### DIFF
--- a/drivers/hv/mshv_vtl_sidecar.c
+++ b/drivers/hv/mshv_vtl_sidecar.c
@@ -153,7 +153,7 @@ static int sidecar_remove(unsigned int cpu)
 	WARN(last != CPU_STATUS_IDLE, "unexpected cpu status %d", last);
 
 	sidecar_signal(dev, cpu);
-	wait_event(dev->wait, READ_ONCE(*slot) == CPU_STATUS_IDLE);
+	wait_event(dev->wait, READ_ONCE(*slot) == CPU_STATUS_REMOVED);
 	dev_info(dev->dev, "cpu %d: remove complete", cpu);
 	last = READ_ONCE(dev->vp_state[cpu_index]);
 	WARN(last != VP_STATE_REMOVED, "unexpected vp state %d", last);


### PR DESCRIPTION
3609a941911e32 still used the wrong wait condition. Fix this, correctly this time.