### PR TITLE
Drivers: hv: mshv_vtl: Don't error out on non-SNP where local maps ar…

### DIFF
--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -2188,10 +2188,11 @@ static long __mshv_ioctl_create_vtl(void __user *user_arg, struct device *module
 	vtl = kzalloc(sizeof(*vtl), GFP_KERNEL);
 	if (!vtl)
 		return -ENOMEM;
-	if (hv_isolation_type_snp())
+	if (hv_isolation_type_snp()) {
 		local_maps = mshv_vtl_setup_local_maps();
-	if (!local_maps)
-		return -ENOMEM;
+		if (!local_maps)
+			return -ENOMEM;
+	}
 
 	fd = get_unused_fd_flags(O_CLOEXEC);
 	if (fd < 0) {


### PR DESCRIPTION
…en't used

Due to the mispalced "if" statement, on non-SNP platforms, creating the VTL pseudo-file would fail.

Don't error out on non-SNP where local maps aren't used

Fixes: 42ba4193d41 ("Drivers: hv: mshv_vtl: Speed up PVALIDATE and RPMADJUST to meet perf targets")