### PR TITLE
Don't let the x86 arch code corrupt memory upon emergency restarting

### DIFF
--- a/arch/x86/hyperv/hv_vtl.c
+++ b/arch/x86/hyperv/hv_vtl.c
@@ -17,6 +17,7 @@
 #include <asm/fpu/xcr.h>
 #include <asm/realmode.h>
 #include <asm/tdx.h>
+#include <asm/reboot.h>
 #include <asm/sev.h>
 #include <uapi/asm/mtrr.h>
 
@@ -45,6 +46,27 @@ static bool hv_vtl_is_private_mmio_tdx(u64 addr)
 	u64 mb_addr = acpi_get_mp_wakeup_mailbox_paddr();
 
 	return mb_addr && within_page(addr, mb_addr);
+}
+
+/*
+ * The `native_machine_emergency_restart` function from `reboot.c` writes
+ * to the physical address 0x472 to indicate the type of reboot for the
+ * firmware. We cannot have that in VSM as the memory composition might
+ * be more generic, and such write effectively corrupts the memory thus
+ * making diagnostics harder at the very least.
+ */
+static void  __noreturn hv_vtl_emergency_restart(void)
+{
+	/*
+	 * Cause a triple fault and the immediate reset. Here the code does not run
+	 * on the top of any firmware, whereby cannot reach out to its services.
+	 * The inifinite loop is for the improbable case that the triple fault does
+	 * not work and have to preserve the state intact for debugging.
+	 */
+	for (;;) {
+		idt_invalidate();
+		__asm__ __volatile__("int3");
+	}
 }
 
 void __init hv_vtl_init_platform(void)
@@ -231,6 +253,7 @@ static int hv_vtl_wakeup_secondary_cpu(u32 apicid, unsigned long start_eip, unsi
 
 int __init hv_vtl_early_init(void)
 {
+	machine_ops.emergency_restart = hv_vtl_emergency_restart;
 	/*
 	 * `boot_cpu_has` returns the runtime feature support,
 	 * and here is the earliest it can be used.

--- a/arch/x86/hyperv/hv_vtl.c
+++ b/arch/x86/hyperv/hv_vtl.c
@@ -69,6 +69,15 @@ static void  __noreturn hv_vtl_emergency_restart(void)
 	}
 }
 
+/*
+ * The only way to restart in the VTL mode is to triple fault as the kernel runs
+ * as firmware.
+ */
+static void  __noreturn hv_vtl_restart(char __maybe_unused *cmd)
+{
+	hv_vtl_emergency_restart();
+}
+
 void __init hv_vtl_init_platform(void)
 {
 	pr_info("Linux runs in Hyper-V Virtual Trust Level\n");
@@ -254,6 +263,8 @@ static int hv_vtl_wakeup_secondary_cpu(u32 apicid, unsigned long start_eip, unsi
 int __init hv_vtl_early_init(void)
 {
 	machine_ops.emergency_restart = hv_vtl_emergency_restart;
+	machine_ops.restart = hv_vtl_restart;
+
 	/*
 	 * `boot_cpu_has` returns the runtime feature support,
 	 * and here is the earliest it can be used.


### PR DESCRIPTION
Applying upstream approved patches: https://lore.kernel.org/all/20250227214728.15672-2-romank@linux.microsoft.com/
@damanm24 repro'ed when servicing