### PR TITLE
Revert "x86/sev: Get cc blob information via boot param address field"

### DIFF
--- a/arch/x86/boot/compressed/sev.c
+++ b/arch/x86/boot/compressed/sev.c
@@ -424,10 +424,6 @@ static struct cc_blob_sev_info *find_cc_blob(struct boot_params *bp)
 {
 	struct cc_blob_sev_info *cc_info;
 
-	/* Boot kernel would have passed the CC blob via boot_params. */
-	if (bp->cc_blob_address)
-		return (struct cc_blob_sev_info *)(unsigned long)bp->cc_blob_address;
-
 	cc_info = find_cc_blob_efi(bp);
 	if (cc_info)
 		goto found_cc_info;
@@ -477,11 +473,9 @@ static bool early_snp_init(struct boot_params *bp)
 	/*
 	 * Pass run-time kernel a pointer to CC info via boot_params so EFI
 	 * config table doesn't need to be searched again during early startup
-	 * phase. Hypervisor also may popualte cc_blob_address directyly
-	 * in direct boot mode.
+	 * phase.
 	 */
-	if (!bp->cc_blob_address)
-		bp->cc_blob_address = (u32)(unsigned long)cc_info;
+	bp->cc_blob_address = (u32)(unsigned long)cc_info;
 
 	return true;
 }
@@ -523,24 +517,17 @@ static int sev_check_cpu_support(void)
 
 void sev_enable(struct boot_params *bp)
 {
-	struct cc_blob_sev_info *cc_info;
 	struct msr m;
 	int bitpos;
 	bool snp;
 
 	/*
-	 * bp->cc_blob_address should only be set by boot/compressed
-	 * kernel and hypervisor with direct boot mode. Initialize it
-	 * to 0 after checking in order to ensure that uninitialized
-	 * values from buggy bootloaders aren't propagated.
+	 * bp->cc_blob_address should only be set by boot/compressed kernel.
+	 * Initialize it to 0 to ensure that uninitialized values from
+	 * buggy bootloaders aren't propagated.
 	 */
-	if (bp) {
-		cc_info = (struct cc_blob_sev_info *)(unsigned long)
-			bp->cc_blob_address;
-
-		if (cc_info->magic != CC_BLOB_SEV_HDR_MAGIC)
-			bp->cc_blob_address = 0;
-	}
+	if (bp)
+		bp->cc_blob_address = 0;
 
 	/*
 	 * Do an initial SEV capability check before early_snp_init() which


### PR DESCRIPTION
This commit was introduced to pass cc blob information via boot param address field to enlightened SEV-SNP guest. OpenHCL may use setup field of boot param to pass cc blob information. So revert the commit.