### PR TITLE
drivers: hv: mshv_vtl: 0 for MSHV_CAP_LOWER_VTL_TIMER_VIRT if unsuppo…

### DIFF
--- a/drivers/hv/mshv_vtl_main.c
+++ b/drivers/hv/mshv_vtl_main.c
@@ -332,7 +332,7 @@ static long __mshv_vtl_ioctl_check_extension(u32 arg)
 	case MSHV_CAP_LOWER_VTL_TIMER_VIRT:
 		if (hv_isolation_type_tdx())
 			return mshv_tdx_vtl_ioctl_check_extension(arg);
-		break;
+		return 0;
 	}
 
 	return -EOPNOTSUPP;


### PR DESCRIPTION
…rted

Returning -EOPNOTSUPP is a fatal error. It means that The driver doesn't know the feature.  Not that the feature is not supported due to the runtime platform reason.  Return 0 for MSHV_CAP_LOWER_VTL_TIMER_VIRT on non-TDX platform, which is safer.

Fixes: 3528fd7a1743 ("drivers: hv: mshv_vtl: Advertise TDX timer service extension")