### PR TITLE
drivers: hv: mshv_vtl: disable TSC_ADJUST handling for CONFIG_HYPERV_VTL_MODE

### DIFF
--- a/arch/x86/hyperv/hv_vtl.c
+++ b/arch/x86/hyperv/hv_vtl.c
@@ -85,6 +85,14 @@ void __init hv_vtl_init_platform(void)
 {
 	pr_info("Linux runs in Hyper-V Virtual Trust Level\n");
 
+	/*
+	 * Disable TSC_ADJUST so that the periodic TSC sync check timer
+	 * (start_sync_check_timer) and related TSC adjustment logic are
+	 * skipped. The TSC exposed via Hyper-V will be consistent across
+	 * processors.
+	 */
+	setup_clear_cpu_cap(X86_FEATURE_TSC_ADJUST);
+
 	x86_init.resources.probe_roms = x86_init_noop;
 	/* There is no paravisor present if we are here. */
 	if (hv_isolation_type_tdx()) {


### PR DESCRIPTION
drivers: hv: mshv_vtl: TSC_ADJUST handling should not be needed for guests running in Hyper-V.

For backward compatibility, turn it off only when built with CONFIG_HYPERV_VTL_MODE. This addresses an issue where the TSC_ADJUST runtime checks would conflict with restore_partition_time handling that would adjust the global TSC value using a Hyper-V hypercall.