### PR TITLE
update branch name to 6.18

### DIFF
--- a/MSFT-Merge/config.json
+++ b/MSFT-Merge/config.json
@@ -1,3 +1,3 @@
 {
-	"branch": "product/underhill-main/6.1"
+	"branch": "product/underhill-dev/6.18"
 }


### PR DESCRIPTION
Update branch name in config.json to 6.18. This string is used by the build pipeline while creating nugets.



Signed-off-by: Hardik Garg <hargar@microsoft.com>