### PR TITLE
x86/hyperv: Fix wrong argument to hv_vtl_bringup_vcpu

### DIFF
--- a/arch/x86/hyperv/hv_vtl.c
+++ b/arch/x86/hyperv/hv_vtl.c
@@ -260,7 +260,7 @@ static int hv_vtl_wakeup_secondary_cpu(u32 apicid, unsigned long start_eip, unsi
 		return -EINVAL;
 	}
 
-	return hv_vtl_bringup_vcpu(vp_index, apicid, start_eip);
+	return hv_vtl_bringup_vcpu(vp_index, cpu, start_eip);
 }
 
 /*

--- a/arch/x86/hyperv/ivm.c
+++ b/arch/x86/hyperv/ivm.c
@@ -298,32 +298,17 @@ int hv_snp_boot_ap(u32 apic_id, unsigned long start_ip, unsigned int cpu)
 	struct sev_es_save_area *cur_vmsa;
 	struct desc_ptr gdtr;
 	struct hv_enable_vp_vtl *start_vp_input;
-	int cpu_id = -EINVAL;
 	unsigned long flags;
-	int vp_index = apic_id;
+	int vp_index;
 	u64 ret, retry = 5;
 
 	if (!vmsa)
 		return -ENOMEM;
 
-#ifdef CONFIG_HYPERV_VTL_MODE
-	int i;
-
-	for_each_possible_cpu(i) {
-		if (per_cpu(x86_cpu_to_apicid, i) == apic_id) {
-			cpu_id = i;
-			break;
-		}
-	}
-
-	if (cpu_id == -EINVAL)
-		panic("%s: no cpu found for APIC ID %d\n", __func__, apic_id);
-
 	/* Find the Hyper-V VP index which might be not the same as APIC ID */
 	vp_index = hv_apicid_to_vp_index(apic_id);
 	if (vp_index < 0 || vp_index > ms_hyperv.max_vp_index)
 		return -EINVAL;
-#endif
 
 	native_store_gdt(&gdtr);
 
@@ -403,13 +388,13 @@ int hv_snp_boot_ap(u32 apic_id, unsigned long start_ip, unsigned int cpu)
 		vmsa = NULL;
 	}
 
-	cur_vmsa = per_cpu(hv_sev_vmsa, cpu_id);
+	cur_vmsa = per_cpu(hv_sev_vmsa, cpu);
 	/* Free up any previous VMSA page */
 	if (cur_vmsa)
 		snp_cleanup_vmsa(cur_vmsa);
 
 	/* Record the current VMSA page */
-	per_cpu(hv_sev_vmsa, cpu_id) = vmsa;
+	per_cpu(hv_sev_vmsa, cpu) = vmsa;
 
 	return ret;
 }

--- a/arch/x86/kernel/cpu/amd.c
+++ b/arch/x86/kernel/cpu/amd.c
@@ -1373,7 +1373,7 @@ static __init int print_s5_reset_status_mmio(void)
 	 * The below ioread32() causes a triple fault for SNP due to a hypevisor
 	 * bug. Work it around for now.
 	 */
-	if (!ms_hyperv.paravisor_present && hv_isolation_type_snp())
+	if (!ms_hyperv.paravisor_present && hv_is_isolation_supported())
 		return 0;
 
 	if (!cpu_feature_enabled(X86_FEATURE_ZEN))


### PR DESCRIPTION
The revert of the TDX reset page commit (3fca7019bb6d8) left `apicid` instead of `cpu` as the second argument to hv_vtl_bringup_vcpu(). This causes secondary CPUs to boot with the wrong idle task stack, leading to stack corruption and triple faults during sidecar servicing.

Fixes: 3fca7019bb6d8 ("Revert "x86/hyperv: Use Hyper-V reset page to boot tdx APs"")


Signed-off-by: Hardik Garg <hargar@microsoft.com>