### PR TITLE
mm: show_mem: add mapped AnonPages to OOM stat dump

### DIFF
--- a/mm/show_mem.c
+++ b/mm/show_mem.c
@@ -200,7 +200,7 @@ static void show_free_areas(unsigned int filter, nodemask_t *nodemask, int max_z
 			free_pcp += per_cpu_ptr(zone->per_cpu_pageset, cpu)->count;
 	}
 
-	printk("active_anon:%lu inactive_anon:%lu isolated_anon:%lu\n"
+	printk("active_anon:%lu inactive_anon:%lu isolated_anon:%lu mapped_anon:%lu\n"
 		" active_file:%lu inactive_file:%lu isolated_file:%lu\n"
 		" unevictable:%lu dirty:%lu writeback:%lu\n"
 		" slab_reclaimable:%lu slab_unreclaimable:%lu\n"
@@ -211,6 +211,7 @@ static void show_free_areas(unsigned int filter, nodemask_t *nodemask, int max_z
 		global_node_page_state(NR_ACTIVE_ANON),
 		global_node_page_state(NR_INACTIVE_ANON),
 		global_node_page_state(NR_ISOLATED_ANON),
+		global_node_page_state(NR_ANON_MAPPED),
 		global_node_page_state(NR_ACTIVE_FILE),
 		global_node_page_state(NR_INACTIVE_FILE),
 		global_node_page_state(NR_ISOLATED_FILE),
@@ -243,6 +244,7 @@ static void show_free_areas(unsigned int filter, nodemask_t *nodemask, int max_z
 			" unevictable:%lukB"
 			" isolated(anon):%lukB"
 			" isolated(file):%lukB"
+			" mapped_anon:%lukB"
 			" mapped:%lukB"
 			" dirty:%lukB"
 			" writeback:%lukB"
@@ -269,6 +271,7 @@ static void show_free_areas(unsigned int filter, nodemask_t *nodemask, int max_z
 			K(node_page_state(pgdat, NR_UNEVICTABLE)),
 			K(node_page_state(pgdat, NR_ISOLATED_ANON)),
 			K(node_page_state(pgdat, NR_ISOLATED_FILE)),
+			K(node_page_state(pgdat, NR_ANON_MAPPED)),
 			K(node_page_state(pgdat, NR_FILE_MAPPED)),
 			K(node_page_state(pgdat, NR_FILE_DIRTY)),
 			K(node_page_state(pgdat, NR_WRITEBACK)),


### PR DESCRIPTION
Adding mapped AnonPages to the `__show_mem` telemetry. This provides additional context on the memory usage from user mode processes on a VTL2 OOM. This statistic can be compared against baseline measurements and Underhill periodic memory status telemetry to provide stronger sources of truth when investigating a VTL2 OOM.