### PR TITLE
drm/ci: bump pinned tooling versions to silence dependabot

### DIFF
--- a/drivers/gpu/drm/ci/xfails/requirements.txt
+++ b/drivers/gpu/drm/ci/xfails/requirements.txt
@@ -2,16 +2,16 @@ git+https://gitlab.freedesktop.org/gfx-ci/ci-collate@09e7142715c16f54344ddf97013
 termcolor==2.3.0
 
 # ci-collate dependencies
-certifi==2023.7.22
+certifi==2024.7.4
 charset-normalizer==3.2.0
-idna==3.4
-pip==23.3
+idna==3.15
+pip==26.1
 python-gitlab==3.15.0
-requests==2.31.0
+requests==2.33.0
 requests-toolbelt==1.0.0
 ruamel.yaml==0.17.32
 ruamel.yaml.clib==0.2.7
-setuptools==70.0.0
+setuptools==78.1.1
 tenacity==8.2.3
-urllib3==2.0.7
-wheel==0.41.1
+urllib3==2.7.0
+wheel==0.46.2


### PR DESCRIPTION
GitHub dependabot reports security advisories against several of the pinned Python packages in `drivers/gpu/drm/ci/xfails/requirements.txt`. Bump each affected package to the minimum patched version called out by the corresponding advisory:

| Package | Old | New | Advisories |
|---|---|---|---|
| certifi    | 2023.7.22 | 2024.7.4  | GHSA-248v-346w-9cwc |
| idna       | 3.4       | 3.15      | GHSA-jjg7-2v4v-x38h + bypass of CVE-2024-3651 fix |
| pip        | 23.3      | 26.1      | tar/ZIP confusion, path traversal, symlink handling, untrusted control sphere |
| requests   | 2.31.0    | 2.33.0    | verify=False session reuse, .netrc leak, insecure temp file reuse |
| setuptools | 70.0.0    | 78.1.1    | GHSA-5rjg-fvgr-3xxf (PackageIndex.download path traversal) |
| urllib3    | 2.0.7     | 2.7.0     | Proxy-Authorization stripping, retry/redirect handling, decompression-bomb hardening |
| wheel      | 0.41.1    | 0.46.2    | GHSA-pxq2-mc46-6943 (path traversal in wheel unpack) |

This closes the 16 currently-open Dependabot alerts in https://github.com/microsoft/OHCL-Linux-Kernel/security/dependabot.

The file is consumed only by the gitlab.freedesktop.org DRM CI tooling (`ci-collate`); none of these packages participate in the kernel build, so there is no kernel build/runtime impact.

### Testing

In a clean `python:3.11` venv:
- `pip install -r drivers/gpu/drm/ci/xfails/requirements.txt` resolves without dependency conflicts.
- All runtime libraries import cleanly (`requests 2.33.0`, `urllib3 2.7.0`, `idna 3.15`, `certifi 2024.7.4`, `ruamel.yaml`, `python-gitlab`, `glcollate`, …).
- `requests.Session()` constructs successfully (cross-validates urllib3/certifi/idna integration).
- `ci-collate --help` runs and shows the expected usage.

Follows the precedent set by upstream commit 58c09cad1754 ("drm/ci: make github dependabot happy again"): bump only the affected packages to the minimum patched version.